### PR TITLE
Bugfix/code spelling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - predeclared
     - exportloopref
     - staticcheck
     - structcheck

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -209,7 +209,7 @@ resource "fusionauth_tenant" "example" {
 ```
 
 ## Argument Reference
-* `source_tentant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
+* `source_tenant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
 * `tenant_id` - (Optional) The Id to use for the new Tenant. If not specified a secure random UUID will be generated.
 * `data` - (Optional) An object that can hold any information about the Tenant that should be persisted.
 * `email_configuration` - (Required)

--- a/fusionauth/client.go
+++ b/fusionauth/client.go
@@ -18,7 +18,7 @@ type Client struct {
 func configureClient(data *schema.ResourceData) (interface{}, error) {
 	key := data.Get("api_key").(string)
 
-	parsedUrl, err := url.Parse(data.Get("host").(string))
+	parsedURL, err := url.Parse(data.Get("host").(string))
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func configureClient(data *schema.ResourceData) (interface{}, error) {
 		&http.Client{
 			Timeout: time.Second * 30,
 		},
-		parsedUrl,
+		parsedURL,
 		key,
 	)
 

--- a/fusionauth/client.go
+++ b/fusionauth/client.go
@@ -18,7 +18,7 @@ type Client struct {
 func configureClient(data *schema.ResourceData) (interface{}, error) {
 	key := data.Get("api_key").(string)
 
-	url, err := url.Parse(data.Get("host").(string))
+	parsedUrl, err := url.Parse(data.Get("host").(string))
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func configureClient(data *schema.ResourceData) (interface{}, error) {
 		&http.Client{
 			Timeout: time.Second * 30,
 		},
-		url,
+		parsedUrl,
 		key,
 	)
 

--- a/fusionauth/datasource_fusionauth_idp.go
+++ b/fusionauth/datasource_fusionauth_idp.go
@@ -12,11 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-type IdenityProvidersResponse struct {
-	IdentityProviders []IdenityProvider `json:"identityProviders"`
+type IdentityProvidersResponse struct {
+	IdentityProviders []IdentityProvider `json:"identityProviders"`
 }
 
-type IdenityProvider struct {
+type IdentityProvider struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	Type string `json:"type"`
@@ -53,12 +53,12 @@ func dataSourceIDP() *schema.Resource {
 
 func dataSourceIDPRead(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
-	b, err := readIdenityProviders(client)
+	b, err := readIdentityProviders(client)
 	if err != nil {
 		return err
 	}
 
-	var idps IdenityProvidersResponse
+	var idps IdentityProvidersResponse
 	_ = json.Unmarshal(b, &idps)
 
 	n := data.Get("name").(string)
@@ -67,7 +67,7 @@ func dataSourceIDPRead(data *schema.ResourceData, i interface{}) error {
 	case "Apple", "Facebook", "Google", "HYPR", "Twitter":
 		n = t
 	}
-	var idp *IdenityProvider
+	var idp *IdentityProvider
 	for i := range idps.IdentityProviders {
 		if idps.IdentityProviders[i].Name == n && idps.IdentityProviders[i].Type == t {
 			idp = &idps.IdentityProviders[i]
@@ -81,7 +81,7 @@ func dataSourceIDPRead(data *schema.ResourceData, i interface{}) error {
 	return nil
 }
 
-func readIdenityProviders(client Client) ([]byte, error) {
+func readIdentityProviders(client Client) ([]byte, error) {
 	req, err := http.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("%s/%s", strings.TrimRight(client.Host, "/"), "api/identity-provider"),

--- a/fusionauth/helpers.go
+++ b/fusionauth/helpers.go
@@ -32,7 +32,7 @@ func checkResponse(statusCode int, faErrors *fusionauth.Errors) error {
 	}
 }
 
-func templateCompare(k, old, new string, d *schema.ResourceData) bool {
+func templateCompare(k, oldStr, newStr string, d *schema.ResourceData) bool {
 	clean := func(s string) string {
 		s = strings.ReplaceAll(s, " ", "")
 		s = strings.ReplaceAll(s, "\t", "")
@@ -40,7 +40,7 @@ func templateCompare(k, old, new string, d *schema.ResourceData) bool {
 		s = strings.ReplaceAll(s, "\n", "")
 		return s
 	}
-	old = clean(old)
-	new = clean(new)
-	return old == new
+	oldStr = clean(oldStr)
+	newStr = clean(newStr)
+	return oldStr == newStr
 }

--- a/fusionauth/idphelpers.go
+++ b/fusionauth/idphelpers.go
@@ -27,7 +27,7 @@ func deleteIdentityProvider(data *schema.ResourceData, i interface{}) error {
 	return nil
 }
 
-func readIdenityProvider(id string, client Client) ([]byte, error) {
+func readIdentityProvider(id string, client Client) ([]byte, error) {
 	req, err := http.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("%s/%s/%s", strings.TrimRight(client.Host, "/"), "api/identity-provider", id),
@@ -61,7 +61,7 @@ func readIdenityProvider(id string, client Client) ([]byte, error) {
 	return b, nil
 }
 
-func createIdenityProvider(b []byte, client Client) ([]byte, error) {
+func createIdentityProvider(b []byte, client Client) ([]byte, error) {
 	req, err := http.NewRequest(
 		http.MethodPost,
 		fmt.Sprintf("%s/%s", strings.TrimRight(client.Host, "/"), "api/identity-provider"),
@@ -95,7 +95,7 @@ func createIdenityProvider(b []byte, client Client) ([]byte, error) {
 	return bb, nil
 }
 
-func updateIdenityProvider(b []byte, id string, client Client) ([]byte, error) {
+func updateIdentityProvider(b []byte, id string, client Client) ([]byte, error) {
 	req, err := http.NewRequest(
 		http.MethodPut,
 		fmt.Sprintf("%s/%s/%s", strings.TrimRight(client.Host, "/"), "api/identity-provider", id),

--- a/fusionauth/resource_fusionauth_idp_apple.go
+++ b/fusionauth/resource_fusionauth_idp_apple.go
@@ -158,7 +158,7 @@ func createIDPApple(data *schema.ResourceData, i interface{}) error {
 
 	client := i.(Client)
 
-	bb, err := createIdenityProvider(b, client)
+	bb, err := createIdentityProvider(b, client)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func createIDPApple(data *schema.ResourceData, i interface{}) error {
 
 func readIDPApple(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
-	b, err := readIdenityProvider(data.Id(), client)
+	b, err := readIdentityProvider(data.Id(), client)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func updateIDPApple(data *schema.ResourceData, i interface{}) error {
 	}
 
 	client := i.(Client)
-	bb, err := updateIdenityProvider(b, data.Id(), client)
+	bb, err := updateIdentityProvider(b, data.Id(), client)
 	if err != nil {
 		return err
 	}

--- a/fusionauth/resource_fusionauth_idp_external_jwt.go
+++ b/fusionauth/resource_fusionauth_idp_external_jwt.go
@@ -144,7 +144,7 @@ func createIDPExternalJWT(data *schema.ResourceData, i interface{}) error {
 
 	client := i.(Client)
 
-	bb, err := createIdenityProvider(b, client)
+	bb, err := createIdentityProvider(b, client)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func createIDPExternalJWT(data *schema.ResourceData, i interface{}) error {
 
 func readIDPExternalJWT(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
-	b, err := readIdenityProvider(data.Id(), client)
+	b, err := readIdentityProvider(data.Id(), client)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func updateIDPExternalJWT(data *schema.ResourceData, i interface{}) error {
 	}
 
 	client := i.(Client)
-	bb, err := updateIdenityProvider(b, data.Id(), client)
+	bb, err := updateIdentityProvider(b, data.Id(), client)
 	if err != nil {
 		return err
 	}

--- a/fusionauth/resource_fusionauth_idp_google.go
+++ b/fusionauth/resource_fusionauth_idp_google.go
@@ -205,7 +205,7 @@ func createIDPGoogle(data *schema.ResourceData, i interface{}) error {
 
 	client := i.(Client)
 
-	bb, err := createIdenityProvider(b, client)
+	bb, err := createIdentityProvider(b, client)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func createIDPGoogle(data *schema.ResourceData, i interface{}) error {
 
 func readIDPGoogle(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
-	b, err := readIdenityProvider(data.Id(), client)
+	b, err := readIdentityProvider(data.Id(), client)
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func updateIDPGoogle(data *schema.ResourceData, i interface{}) error {
 	}
 
 	client := i.(Client)
-	bb, err := updateIdenityProvider(b, data.Id(), client)
+	bb, err := updateIdentityProvider(b, data.Id(), client)
 	if err != nil {
 		return err
 	}

--- a/fusionauth/resource_fusionauth_idp_open_id_connect.go
+++ b/fusionauth/resource_fusionauth_idp_open_id_connect.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-type OpenIDConnectIdenityProviderBody struct {
+type OpenIDConnectIdentityProviderBody struct {
 	IdentityProvider fusionauth.OpenIdConnectIdentityProvider `json:"identityProvider"`
 }
 
@@ -206,7 +206,7 @@ func newIDPOpenIDConnect() *schema.Resource {
 	}
 }
 
-func buildOpenIDConnect(data *schema.ResourceData) OpenIDConnectIdenityProviderBody {
+func buildOpenIDConnect(data *schema.ResourceData) OpenIDConnectIdentityProviderBody {
 	o := fusionauth.OpenIdConnectIdentityProvider{
 		ButtonImageURL: data.Get("button_image_url").(string),
 		ButtonText:     data.Get("button_text").(string),
@@ -240,7 +240,7 @@ func buildOpenIDConnect(data *schema.ResourceData) OpenIDConnectIdenityProviderB
 
 	ac := buildOpenIDAppConfig("application_configuration", data)
 	o.ApplicationConfiguration = ac
-	return OpenIDConnectIdenityProviderBody{IdentityProvider: o}
+	return OpenIDConnectIdentityProviderBody{IdentityProvider: o}
 }
 
 func buildOpenIDAppConfig(key string, data *schema.ResourceData) map[string]interface{} {
@@ -279,7 +279,7 @@ func createOpenIDConnect(data *schema.ResourceData, i interface{}) error {
 	}
 
 	client := i.(Client)
-	bb, err := createIdenityProvider(b, client)
+	bb, err := createIdentityProvider(b, client)
 	if err != nil {
 		return err
 	}
@@ -295,12 +295,12 @@ func createOpenIDConnect(data *schema.ResourceData, i interface{}) error {
 
 func readOpenIDConnect(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
-	b, err := readIdenityProvider(data.Id(), client)
+	b, err := readIdentityProvider(data.Id(), client)
 	if err != nil {
 		return err
 	}
 
-	var ipb OpenIDConnectIdenityProviderBody
+	var ipb OpenIDConnectIdentityProviderBody
 	_ = json.Unmarshal(b, &ipb)
 
 	return buildResourceFromOpenIDConnect(ipb.IdentityProvider, data)
@@ -398,7 +398,7 @@ func updateOpenIDConnect(data *schema.ResourceData, i interface{}) error {
 	}
 
 	client := i.(Client)
-	bb, err := updateIdenityProvider(b, data.Id(), client)
+	bb, err := updateIdentityProvider(b, data.Id(), client)
 	if err != nil {
 		return err
 	}

--- a/fusionauth/resource_fusionauth_idp_samlv2.go
+++ b/fusionauth/resource_fusionauth_idp_samlv2.go
@@ -185,7 +185,7 @@ func createIDPSAMLv2(data *schema.ResourceData, i interface{}) error {
 	}
 
 	client := i.(Client)
-	bb, err := createIdenityProvider(b, client)
+	bb, err := createIdentityProvider(b, client)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func createIDPSAMLv2(data *schema.ResourceData, i interface{}) error {
 }
 func readIDPSAMLv2(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
-	b, err := readIdenityProvider(data.Id(), client)
+	b, err := readIdentityProvider(data.Id(), client)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func updateIDPSAMLv2(data *schema.ResourceData, i interface{}) error {
 	}
 
 	client := i.(Client)
-	bb, err := updateIdenityProvider(b, data.Id(), client)
+	bb, err := updateIdentityProvider(b, data.Id(), client)
 	if err != nil {
 		return err
 	}

--- a/fusionauth/resource_fusionauth_tenant_crud.go
+++ b/fusionauth/resource_fusionauth_tenant_crud.go
@@ -11,8 +11,8 @@ import (
 func createTenant(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
 	t := fusionauth.TenantRequest{
-		Tenant:         buildTentant(data),
-		SourceTenantId: data.Get("source_tentant_id").(string),
+		Tenant:         buildTenant(data),
+		SourceTenantId: data.Get("source_tenant_id").(string),
 	}
 
 	var tid string
@@ -57,8 +57,8 @@ func updateTenant(data *schema.ResourceData, i interface{}) error {
 	client := i.(Client)
 
 	t := fusionauth.TenantRequest{
-		Tenant:         buildTentant(data),
-		SourceTenantId: data.Get("source_tentant_id").(string),
+		Tenant:         buildTenant(data),
+		SourceTenantId: data.Get("source_tenant_id").(string),
 	}
 
 	resp, faErrs, err := client.FAClient.UpdateTenant(data.Id(), t)

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func buildTentant(data *schema.ResourceData) fusionauth.Tenant {
+func buildTenant(data *schema.ResourceData) fusionauth.Tenant {
 	return fusionauth.Tenant{
 		Data: data.Get("data").(map[string]interface{}),
 		EmailConfiguration: fusionauth.EmailConfiguration{

--- a/fusionauth/schema_fusionauth_tenant.go
+++ b/fusionauth/schema_fusionauth_tenant.go
@@ -12,7 +12,7 @@ func newTenant() *schema.Resource {
 		Update: updateTenant,
 		Delete: deleteTenant,
 		Schema: map[string]*schema.Schema{
-			"source_tentant_id": {
+			"source_tenant_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.",


### PR DESCRIPTION
This PR fixes a number of spelling issues and a couple of variable shadowing issues which leads to breaking changes:

* `tentant` => `tenant`
* `source_tentant_id` => `source_tenant_id`
* `idenity` => `identity`
* `var url` => `var parsedUrl`
* `var delete` => now defined in the map and uses existence checking instead.