### PR TITLE
fix: fixes secure generator types.

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -128,6 +128,10 @@ resource "fusionauth_tenant" "example" {
       type   = "randomBytes"
     }
     email_verification_id_time_to_live_in_seconds      = 86400
+    email_verification_one_time_code_generator {
+      length = 6
+      type   = "randomAlphaNumeric"
+    }
     external_authentication_id_time_to_live_in_seconds = 300
     one_time_password_time_to_live_in_seconds          = 60
     passwordless_login_generator {
@@ -140,6 +144,10 @@ resource "fusionauth_tenant" "example" {
       type   = "randomBytes"
     }
     registration_verification_id_time_to_live_in_seconds = 86400
+    registration_verification_one_time_code_generator {
+      length = 6
+      type   = "randomAlphaNumeric"
+    }
     saml_v2_authn_request_id_ttl_seconds = 300
     setup_password_id_generator {
       length = 32
@@ -147,6 +155,10 @@ resource "fusionauth_tenant" "example" {
     }
     setup_password_id_time_to_live_in_seconds   = 86400
     two_factor_id_time_to_live_in_seconds       = 300
+    two_factor_one_time_code_id_generator {
+      length = 6
+      type   = "randomDigits"
+    }
     two_factor_trust_id_time_to_live_in_seconds = 2592000
   }
   failed_authentication_configuration {

--- a/fusionauth/schema_fusionauth_tenant.go
+++ b/fusionauth/schema_fusionauth_tenant.go
@@ -1,6 +1,7 @@
 package fusionauth
 
 import (
+	"github.com/FusionAuth/go-client/pkg/fusionauth"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -583,15 +584,10 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the change password Id.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the change password Id.",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the change password Id.",
 						},
 					},
 				},
@@ -620,15 +616,10 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the change password Id.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the change password Id.",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the change password Id.",
 						},
 					},
 				},
@@ -645,15 +636,10 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the change password Id.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the change password Id.",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the change password Id.",
 						},
 					},
 				},
@@ -670,16 +656,11 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the email verification one time code.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "randomAlphaNumeric",
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the email verification one time code.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      string(fusionauth.SecureGeneratorType_RandomAlphaNumeric),
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the email verification one time code.",
 						},
 					},
 				},
@@ -714,15 +695,10 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the change password Id.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the change password Id.",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the change password Id.",
 						},
 					},
 				},
@@ -745,15 +721,10 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the change password Id.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the change password Id.",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the change password Id.",
 						},
 					},
 				},
@@ -770,16 +741,11 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the registration verification one time code.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "randomAlphaNumeric",
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the registration verification one time code.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      string(fusionauth.SecureGeneratorType_RandomAlphaNumeric),
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the registration verification one time code.",
 						},
 					},
 				},
@@ -808,15 +774,10 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the change password Id.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the change password Id.",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the change password Id.",
 						},
 					},
 				},
@@ -839,16 +800,11 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 							Description: "The length of the secure generator used for generating the the two factor code Id.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "randomAlphaNumeric",
-							ValidateFunc: validation.StringInSlice([]string{
-								"randomAlpha",
-								"randomAlphaNumeric",
-								"randomBytes",
-								"randomDigits.",
-							}, false),
-							Description: "The type of the secure generator used for generating the two factor one time code Id.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      string(fusionauth.SecureGeneratorType_RandomAlphaNumeric),
+							ValidateFunc: validation.StringInSlice(secureGeneratorTypes(), false),
+							Description:  "The type of the secure generator used for generating the two factor one time code Id.",
 						},
 					},
 				},
@@ -1082,5 +1038,15 @@ func newPasswordValidationRules() *schema.Resource {
 				Description: "When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.",
 			},
 		},
+	}
+}
+
+// secureGeneratorTypes returns a list of the valid secure generator types.
+func secureGeneratorTypes() []string {
+	return []string{
+		string(fusionauth.SecureGeneratorType_RandomAlpha),
+		string(fusionauth.SecureGeneratorType_RandomAlphaNumeric),
+		string(fusionauth.SecureGeneratorType_RandomBytes),
+		string(fusionauth.SecureGeneratorType_RandomDigits),
 	}
 }


### PR DESCRIPTION
Noticed `randomDigits.` had a period on it and got a Terraform verification error when I copied over an example tenant block for `tenant.twoFactorOneTimeCodeIdGenerator`.