### PR TITLE
Fix: API Key Documentation

### DIFF
--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -11,7 +11,7 @@ The FusionAuth APIs are primarily secured using API keys. This API can only be a
 resource "fusionauth_api_key" "example" {
   tenant_id   = "94f751c5-4883-4684-a817-6b106778edec"
   description = "my super secret key"
-  key         = "super-secret-key
+  key         = "super-secret-key"
   permissions_endpoints {
     endpoint = "/api/application"
     get      = true


### PR DESCRIPTION
fix(docs/resources/api_key.md): issue in documentation with terraform syntax missing a closing double quote