### PR TITLE
Add entity support

### DIFF
--- a/docs/resources/entity.md
+++ b/docs/resources/entity.md
@@ -1,0 +1,25 @@
+# Entity Resource
+
+Entities are instantiations of entity types used for permissions and client credentials.
+Entities are associated with an entity type and a tenant.
+
+[Entity API](https://fusionauth.io/docs/v1/tech/apis/entity-management/entities/)
+
+## Example
+
+```hcl
+resource "fusionauth_entity" "light_switch" {
+  tenant_id = fusionauth_tenant.house.id
+  entity_type_id = fusionauth_entity_type.switch.id
+  name = "Light Switch"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the type.
+* `tenant_id` - (Required) The id of the entity's tenant
+* `entity_type_id` - (Required) The ID of the entity's type
+* `client_id` - (Optional) the client ID for the entity
+* `client_secret` - (Optional) The client secret for the entity
+* `data` - (Optional) An object that can hold any information about the entity that should be persisted.

--- a/docs/resources/entity_grant.md
+++ b/docs/resources/entity_grant.md
@@ -1,0 +1,26 @@
+# Entity Grant Resource
+
+The grant of access between a receiving user or entity and a target entity.
+Each grant confers a set of permissions on the receiver to the target.
+
+[Entity Grants - API](https://fusionauth.io/docs/v1/tech/apis/entity-management/grants/)
+
+## Example
+
+```hcl
+resource "fusionauth_entity_grant" "robot_toggle_door_switch" {
+  grant_entity_id =  fusionauth_entity.light_switch.id
+  recipient_entity_id = fusionauth_entity.robot.id
+  permissions = [fusionauth_entity_type_permission.toggle.name]
+}
+```
+
+Note that permissions are associated by the permission name rather than id.
+
+## Argument Reference
+
+* `grant_entity_id` - (Required) The target entity. This is the entity that actions will be taken against
+* `recipient_entity_id` - (Optional) The ID of the entity type that should receive the permissions. If this is unset, then user_id should be set instead.
+* `user_id` - (Optional) The ID of a user that should receive the permissions. If this is unset, then recipient_entity_id should be set instead.
+* `permissions` - (Optional) An array of permission names that should be granted to the recipient (either user or entity).
+* `data` - (Optional) Additional data that should be associated with the entity grant.

--- a/docs/resources/entity_type.md
+++ b/docs/resources/entity_type.md
@@ -1,0 +1,22 @@
+# Entity Type Resource
+
+Entity types serve as archetypes for entities. 
+Permissions that can be granted for individual entities are defined on entity types. 
+The provider models this as anadditional entity_type_permission resource.
+For more information see the official documentation
+
+[Entity Type API](https://fusionauth.io/docs/v1/tech/apis/entity-management/entity-types/)
+
+## Example
+
+```hcl
+resource "fusionauth_entity_type" "switch" {
+  name = "switch"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the type.
+* `entity_type_id` - (Optional) A specific UUID to use as the id for the type
+* `data` - (Optional) An object that can hold any information about the type that should be persisted.

--- a/docs/resources/entity_type_permission.md
+++ b/docs/resources/entity_type_permission.md
@@ -1,0 +1,22 @@
+# Entity Type Permission Resource
+
+A resource for permissions that are associated with entity types.
+These permissions can then be granted to either entities or user receipients for specific entities.
+
+[Entity Type API - Grants](https://fusionauth.io/docs/v1/tech/apis/entity-management/entity-types/#create-an-entity-type-permission)
+
+## Example
+
+```hcl
+resource "fusionauth_entity_type_permission" "switch_toggle" {
+  entity_type_id = fusionauth_entity_type.switch.id
+  name = "Toggle Switch"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the permission.
+* `entity_type_id` - (Required) The ID of the entity type to create a permission on
+* `description` - (Optional) long form description of the permission
+* `is_default` - (Optional) should the permission be granted by default when a permission grant is created for an entity of the type this permission is associated with.

--- a/fusionauth/provider.go
+++ b/fusionauth/provider.go
@@ -50,6 +50,7 @@ func Provider() *schema.Provider {
 			"fusionauth_idp_facebook":             resourceIDPFacebook(),
 			"fusionauth_entity_type":              newEntityType(),
 			"fusionauth_entity":                   newEntity(),
+			"fusionauth_entity_grant":             newEntityGrant(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"fusionauth_lambda":           dataSourceLambda(),

--- a/fusionauth/provider.go
+++ b/fusionauth/provider.go
@@ -49,6 +49,7 @@ func Provider() *schema.Provider {
 			"fusionauth_idp_twitch":               resourceIDPTwitch(),
 			"fusionauth_idp_facebook":             resourceIDPFacebook(),
 			"fusionauth_entity_type":              newEntityType(),
+			"fusionauth_entity_type_permission":   newEntityTypePermission(),
 			"fusionauth_entity":                   newEntity(),
 			"fusionauth_entity_grant":             newEntityGrant(),
 		},

--- a/fusionauth/provider.go
+++ b/fusionauth/provider.go
@@ -49,6 +49,7 @@ func Provider() *schema.Provider {
 			"fusionauth_idp_twitch":               resourceIDPTwitch(),
 			"fusionauth_idp_facebook":             resourceIDPFacebook(),
 			"fusionauth_entity_type":              newEntityType(),
+			"fusionauth_entity":                   newEntity(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"fusionauth_lambda":           dataSourceLambda(),

--- a/fusionauth/provider.go
+++ b/fusionauth/provider.go
@@ -48,6 +48,7 @@ func Provider() *schema.Provider {
 			"fusionauth_idp_steam":                resourceIDPSteam(),
 			"fusionauth_idp_twitch":               resourceIDPTwitch(),
 			"fusionauth_idp_facebook":             resourceIDPFacebook(),
+			"fusionauth_entity_type":              newEntityType(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"fusionauth_lambda":           dataSourceLambda(),

--- a/fusionauth/resource_fusionauth_application.go
+++ b/fusionauth/resource_fusionauth_application.go
@@ -97,6 +97,7 @@ func newApplication() *schema.Resource {
 				MaxItems: 1,
 				Elem:     newJWTConfiguration(),
 				Optional: true,
+				Computed: true,
 			},
 			"lambda_configuration": {
 				Type:       schema.TypeList,
@@ -128,6 +129,7 @@ func newApplication() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allow_token_refresh": {
@@ -184,12 +186,14 @@ func newApplication() *schema.Resource {
 				MaxItems: 1,
 				Elem:     newOAuthConfiguration(),
 				Optional: true,
+				Computed: true,
 			},
 			"registration_configuration": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem:     newRegistrationConfiguration(),
 				Optional: true,
+				Computed: true,
 			},
 			"passwordless_configuration_enabled": {
 				Type:        schema.TypeBool,
@@ -201,6 +205,7 @@ func newApplication() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"unverified_enabled": {

--- a/fusionauth/resource_fusionauth_entity.go
+++ b/fusionauth/resource_fusionauth_entity.go
@@ -1,0 +1,196 @@
+package fusionauth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/FusionAuth/go-client/pkg/fusionauth"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func newEntity() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createEntity,
+		ReadContext:   readEntity,
+		UpdateContext: updateEntity,
+		DeleteContext: deleteEntity,
+		Schema: map[string]*schema.Schema{
+			"entity_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The id of the entity",
+				ValidateFunc: validation.IsUUID,
+			},
+			"entity_type_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The id of the entity type",
+				ValidateFunc: validation.IsUUID,
+			},
+			"tenant_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The tenant the entity lives in",
+				ValidateFunc: validation.IsUUID,
+			},
+			"client_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The client_id for this entity",
+				ValidateFunc: validation.IsUUID,
+			},
+			"client_secret": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The client_secret for this entity",
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The parent for this entity",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the entity",
+			},
+			"data": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "An object that can hold any information about the entity that should be persisted.",
+			},
+		},
+	}
+}
+
+func createEntity(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	var id string
+	if eid, ok := data.GetOk("entity_id"); ok {
+		id = eid.(string)
+	}
+	entity := createEntityFromData(data)
+
+	oldTenantId := client.FAClient.TenantId
+	client.FAClient.TenantId = entity.TenantId
+
+	defer func() {
+		client.FAClient.TenantId = oldTenantId
+	}()
+
+	resp, faErrs, err := client.FAClient.CreateEntity(id, fusionauth.EntityRequest{Entity: entity})
+
+	if err != nil {
+		return diag.Errorf("CreateEntity err: %v", err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return entityToData(&resp.Entity, data)
+}
+
+func readEntity(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+
+	resp, faErrs, err := client.FAClient.RetrieveEntity(id)
+	if err != nil {
+		return diag.Errorf("RetrieveEntity err: %v", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		data.SetId("")
+		return nil
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+	return entityToData(&resp.Entity, data)
+}
+
+func updateEntity(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+
+	entity := createEntityFromData(data)
+
+	oldTenantId := client.FAClient.TenantId
+	client.FAClient.TenantId = entity.TenantId
+
+	defer func() {
+		client.FAClient.TenantId = oldTenantId
+	}()
+
+	resp, faErrs, err := client.FAClient.UpdateEntity(id, fusionauth.EntityRequest{Entity: entity})
+	if err != nil {
+		return diag.Errorf("UpdateEntity err: %v", err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func deleteEntity(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+
+	resp, faErrs, err := client.FAClient.DeleteEntity(id)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func createEntityFromData(data *schema.ResourceData) fusionauth.Entity {
+	return fusionauth.Entity{
+		ClientId:     data.Get("client_id").(string),
+		ClientSecret: data.Get("client_secret").(string),
+		Data:         data.Get("data").(map[string]interface{}),
+		Name:         data.Get("name").(string),
+		ParentId:     data.Get("parent_id").(string),
+		TenantId:     data.Get("tenant_id").(string),
+		// Is this sufficient for the API to function? There is a whole EntityType here
+		Type: fusionauth.EntityType{Id: data.Get("entity_type_id").(string)},
+	}
+}
+
+func entityToData(entity *fusionauth.Entity, data *schema.ResourceData) diag.Diagnostics {
+	data.SetId(entity.Id)
+	if err := data.Set("entity_id", entity.Id); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("entity_type_id", entity.Type.Id); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("tenant_id", entity.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("client_id", entity.ClientId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("client_secret", entity.ClientSecret); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("parent_id", entity.ParentId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("name", entity.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("data", entity.Data); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/fusionauth/resource_fusionauth_entity.go
+++ b/fusionauth/resource_fusionauth_entity.go
@@ -21,6 +21,7 @@ func newEntity() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
+				ForceNew:     true,
 				Description:  "The id of the entity",
 				ValidateFunc: validation.IsUUID,
 			},
@@ -99,6 +100,13 @@ func createEntity(_ context.Context, data *schema.ResourceData, i interface{}) d
 func readEntity(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	id := data.Id()
+
+	oldTenantId := client.FAClient.TenantId
+	client.FAClient.TenantId = data.Get("tenant_id").(string)
+
+	defer func() {
+		client.FAClient.TenantId = oldTenantId
+	}()
 
 	resp, faErrs, err := client.FAClient.RetrieveEntity(id)
 	if err != nil {

--- a/fusionauth/resource_fusionauth_entity.go
+++ b/fusionauth/resource_fusionauth_entity.go
@@ -149,6 +149,13 @@ func deleteEntity(_ context.Context, data *schema.ResourceData, i interface{}) d
 	client := i.(Client)
 	id := data.Id()
 
+	oldTenantId := client.FAClient.TenantId
+	client.FAClient.TenantId = data.Get("tenant_id").(string)
+
+	defer func() {
+		client.FAClient.TenantId = oldTenantId
+	}()
+
 	resp, faErrs, err := client.FAClient.DeleteEntity(id)
 
 	if err != nil {

--- a/fusionauth/resource_fusionauth_entity.go
+++ b/fusionauth/resource_fusionauth_entity.go
@@ -149,11 +149,11 @@ func deleteEntity(_ context.Context, data *schema.ResourceData, i interface{}) d
 	client := i.(Client)
 	id := data.Id()
 
-	oldTenantId := client.FAClient.TenantId
+	oldTenantID := client.FAClient.TenantId
 	client.FAClient.TenantId = data.Get("tenant_id").(string)
 
 	defer func() {
-		client.FAClient.TenantId = oldTenantId
+		client.FAClient.TenantId = oldTenantID
 	}()
 
 	resp, faErrs, err := client.FAClient.DeleteEntity(id)

--- a/fusionauth/resource_fusionauth_entity.go
+++ b/fusionauth/resource_fusionauth_entity.go
@@ -78,11 +78,11 @@ func createEntity(_ context.Context, data *schema.ResourceData, i interface{}) d
 	}
 	entity := createEntityFromData(data)
 
-	oldTenantId := client.FAClient.TenantId
+	oldTenantID := client.FAClient.TenantId
 	client.FAClient.TenantId = entity.TenantId
 
 	defer func() {
-		client.FAClient.TenantId = oldTenantId
+		client.FAClient.TenantId = oldTenantID
 	}()
 
 	resp, faErrs, err := client.FAClient.CreateEntity(id, fusionauth.EntityRequest{Entity: entity})
@@ -101,11 +101,11 @@ func readEntity(_ context.Context, data *schema.ResourceData, i interface{}) dia
 	client := i.(Client)
 	id := data.Id()
 
-	oldTenantId := client.FAClient.TenantId
+	oldTenantID := client.FAClient.TenantId
 	client.FAClient.TenantId = data.Get("tenant_id").(string)
 
 	defer func() {
-		client.FAClient.TenantId = oldTenantId
+		client.FAClient.TenantId = oldTenantID
 	}()
 
 	resp, faErrs, err := client.FAClient.RetrieveEntity(id)
@@ -128,11 +128,11 @@ func updateEntity(_ context.Context, data *schema.ResourceData, i interface{}) d
 
 	entity := createEntityFromData(data)
 
-	oldTenantId := client.FAClient.TenantId
+	oldTenantID := client.FAClient.TenantId
 	client.FAClient.TenantId = entity.TenantId
 
 	defer func() {
-		client.FAClient.TenantId = oldTenantId
+		client.FAClient.TenantId = oldTenantID
 	}()
 
 	resp, faErrs, err := client.FAClient.UpdateEntity(id, fusionauth.EntityRequest{Entity: entity})

--- a/fusionauth/resource_fusionauth_entity_grant.go
+++ b/fusionauth/resource_fusionauth_entity_grant.go
@@ -124,7 +124,7 @@ func updateEntityGrant(_ context.Context, data *schema.ResourceData, i interface
 }
 
 func synthesizeEntityGrantId(entityId string, recipientEntityId string) string {
-	return fmt.Sprintf("%s::%s", entityId, recipientEntityId)
+	return fmt.Sprintf("%s::entity::%s", entityId, recipientEntityId)
 }
 
 func entityGrantToData(entityGrant *fusionauth.EntityGrant, data *schema.ResourceData) diag.Diagnostics {
@@ -144,12 +144,21 @@ func deleteEntityGrant(_ context.Context, data *schema.ResourceData, i interface
 	client := i.(Client)
 
 	id := data.Id()
-	parts := strings.SplitN(id, "::", 2)
+	parts := strings.SplitN(id, "::", 3)
 
 	grantEntityId := parts[0]
 	recipientEntityId := parts[1]
 
-	resp, faErrs, err := client.FAClient.DeleteEntityGrant(grantEntityId, recipientEntityId, "")
+	var resp *fusionauth.BaseHTTPResponse
+	var faErrs *fusionauth.Errors
+	var err error
+
+	if parts[1] == "entity" {
+		resp, faErrs, err = client.FAClient.DeleteEntityGrant(grantEntityId, recipientEntityId, "")
+	} else {
+		return diag.Errorf("Entity grant id is malformed, unrecognized switch type %s", parts[1])
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fusionauth/resource_fusionauth_entity_grant.go
+++ b/fusionauth/resource_fusionauth_entity_grant.go
@@ -97,8 +97,10 @@ func synthesizeEntityGrantId(entityId string, recipientEntityId string) string {
 }
 
 func entityGrantToData(entityGrant *fusionauth.EntityGrant, data *schema.ResourceData) diag.Diagnostics {
+	// The EntityGrant has an id, but there doesn't appear to be a way to find it later by that id
+	// So, we generate a synthetic id containing the grant entity and the recipient identity to use for lookup later
 	data.SetId(synthesizeEntityGrantId(entityGrant.Id, entityGrant.RecipientEntityId))
-	if err := data.Set("grant_entity_id", entityGrant.Id); err != nil {
+	if err := data.Set("grant_entity_id", entityGrant.Entity.Id); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := data.Set("recipient_entity_id", entityGrant.RecipientEntityId); err != nil {
@@ -106,12 +108,6 @@ func entityGrantToData(entityGrant *fusionauth.EntityGrant, data *schema.Resourc
 	}
 	return nil
 }
-
-// func updateEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-// 	client := i.(Client)
-
-// 	return nil
-// }
 
 func deleteEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)

--- a/fusionauth/resource_fusionauth_entity_grant.go
+++ b/fusionauth/resource_fusionauth_entity_grant.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/FusionAuth/go-client/pkg/fusionauth"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -115,8 +116,11 @@ func entityGrantToData(entityGrant *fusionauth.EntityGrant, data *schema.Resourc
 func deleteEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 
-	grantEntityId := data.Get("entity_grant_id").(string)
-	recipientEntityId := data.Get("recipient_entity_id").(string)
+	id := data.Id()
+	parts := strings.SplitN(id, "::", 2)
+
+	grantEntityId := parts[0]
+	recipientEntityId := parts[1]
 
 	resp, faErrs, err := client.FAClient.DeleteEntityGrant(grantEntityId, recipientEntityId, "")
 	if err != nil {

--- a/fusionauth/resource_fusionauth_entity_grant.go
+++ b/fusionauth/resource_fusionauth_entity_grant.go
@@ -87,13 +87,13 @@ func createEntityGrantFromData(data *schema.ResourceData) (d diag.Diagnostics, r
 	}
 
 	var recipientID string
-	var userId string
+	var userID string
 	if id, ok := data.GetOk("recipient_entity_id"); ok {
 		recipientID = id.(string)
 		resourceIDSuffix = fmt.Sprintf("entity::%s", recipientID)
 	} else if id, ok := data.GetOk("user_id"); ok {
-		userId = id.(string)
-		resourceIDSuffix = fmt.Sprintf("user::%s", userId)
+		userID = id.(string)
+		resourceIDSuffix = fmt.Sprintf("user::%s", userID)
 	} else {
 		return diag.Errorf("Either recipient_entity_id or user_id must be set"), "", nil
 	}
@@ -102,7 +102,7 @@ func createEntityGrantFromData(data *schema.ResourceData) (d diag.Diagnostics, r
 		// TODO: The API supports granting users this way as well.
 		// Probably should select 1 or the other rather than assuming recipient_
 		RecipientEntityId: recipientID,
-		UserId:            userId,
+		UserId:            userID,
 		Permissions:       perms,
 	}
 }
@@ -110,10 +110,10 @@ func createEntityGrantFromData(data *schema.ResourceData) (d diag.Diagnostics, r
 func readEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 
-	grantEntityId := data.Get("grant_entity_id").(string)
-	recipientEntityId := data.Get("recipient_entity_id").(string)
+	grantEntityID := data.Get("grant_entity_id").(string)
+	recipientEntityID := data.Get("recipient_entity_id").(string)
 
-	resp, faErrs, err := client.FAClient.RetrieveEntityGrant(grantEntityId, recipientEntityId, "")
+	resp, faErrs, err := client.FAClient.RetrieveEntityGrant(grantEntityID, recipientEntityID, "")
 
 	if err != nil {
 		return diag.Errorf("SearchEntityGrants '%v'", err)
@@ -131,14 +131,14 @@ func readEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}
 
 func updateEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
-	grantEntityId := data.Get("grant_entity_id").(string)
+	grantEntityID := data.Get("grant_entity_id").(string)
 	dg, _, entityGrant := createEntityGrantFromData(data)
 
 	if dg != nil {
 		return dg
 	}
 
-	resp, faErrs, err := client.FAClient.UpsertEntityGrant(grantEntityId, fusionauth.EntityGrantRequest{Grant: *entityGrant})
+	resp, faErrs, err := client.FAClient.UpsertEntityGrant(grantEntityID, fusionauth.EntityGrantRequest{Grant: *entityGrant})
 
 	if err != nil {
 		return diag.Errorf("UpsertEntityGrant err: %v", err)
@@ -178,15 +178,15 @@ func deleteEntityGrant(_ context.Context, data *schema.ResourceData, i interface
 		return diag.Errorf("Inexplicable fusionauth_entity_grant id of %s does not match expected pattern", id)
 	}
 
-	grantEntityId := parts[0]
-	recipientEntityId := parts[2]
+	grantEntityID := parts[0]
+	recipientEntityID := parts[2]
 
 	var resp *fusionauth.BaseHTTPResponse
 	var faErrs *fusionauth.Errors
 	var err error
 
 	if parts[1] == "entity" {
-		resp, faErrs, err = client.FAClient.DeleteEntityGrant(grantEntityId, recipientEntityId, "")
+		resp, faErrs, err = client.FAClient.DeleteEntityGrant(grantEntityID, recipientEntityID, "")
 	} else {
 		return diag.Errorf("Entity grant id is malformed, unrecognized switch type %s", parts[1])
 	}

--- a/fusionauth/resource_fusionauth_entity_grant.go
+++ b/fusionauth/resource_fusionauth_entity_grant.go
@@ -57,13 +57,13 @@ func newEntityGrant() *schema.Resource {
 
 func createEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
-	grantEntityId := data.Get("grant_entity_id").(string)
-	dg, resourceIdSuffix, entityGrant := createEntityGrantFromData(data)
+	grantEntityID := data.Get("grant_entity_id").(string)
+	dg, resourceIDSuffix, entityGrant := createEntityGrantFromData(data)
 	if dg != nil {
 		return dg
 	}
 
-	resp, faErrs, err := client.FAClient.UpsertEntityGrant(grantEntityId, fusionauth.EntityGrantRequest{Grant: *entityGrant})
+	resp, faErrs, err := client.FAClient.UpsertEntityGrant(grantEntityID, fusionauth.EntityGrantRequest{Grant: *entityGrant})
 
 	if err != nil {
 		return diag.Errorf("UpsertEntityGrant err: %v", err)
@@ -72,12 +72,12 @@ func createEntityGrant(_ context.Context, data *schema.ResourceData, i interface
 		return diag.FromErr(err)
 	}
 
-	data.SetId(fmt.Sprintf("%s::%s", grantEntityId, resourceIdSuffix))
+	data.SetId(fmt.Sprintf("%s::%s", grantEntityID, resourceIDSuffix))
 
 	return nil
 }
 
-func createEntityGrantFromData(data *schema.ResourceData) (d diag.Diagnostics, resourceIdSuffix string, entity *fusionauth.EntityGrant) {
+func createEntityGrantFromData(data *schema.ResourceData) (d diag.Diagnostics, resourceIDSuffix string, entity *fusionauth.EntityGrant) {
 	var perms []string
 	if setPermsRaw, ok := data.GetOk("permissions"); ok {
 		setPerms := setPermsRaw.([]interface{})
@@ -86,22 +86,22 @@ func createEntityGrantFromData(data *schema.ResourceData) (d diag.Diagnostics, r
 		}
 	}
 
-	var recipientId string
+	var recipientID string
 	var userId string
 	if id, ok := data.GetOk("recipient_entity_id"); ok {
-		recipientId = id.(string)
-		resourceIdSuffix = fmt.Sprintf("entity::%s", recipientId)
+		recipientID = id.(string)
+		resourceIDSuffix = fmt.Sprintf("entity::%s", recipientID)
 	} else if id, ok := data.GetOk("user_id"); ok {
 		userId = id.(string)
-		resourceIdSuffix = fmt.Sprintf("user::%s", userId)
+		resourceIDSuffix = fmt.Sprintf("user::%s", userId)
 	} else {
 		return diag.Errorf("Either recipient_entity_id or user_id must be set"), "", nil
 	}
 
-	return nil, resourceIdSuffix, &fusionauth.EntityGrant{
+	return nil, resourceIDSuffix, &fusionauth.EntityGrant{
 		// TODO: The API supports granting users this way as well.
 		// Probably should select 1 or the other rather than assuming recipient_
-		RecipientEntityId: recipientId,
+		RecipientEntityId: recipientID,
 		UserId:            userId,
 		Permissions:       perms,
 	}
@@ -116,7 +116,7 @@ func readEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}
 	resp, faErrs, err := client.FAClient.RetrieveEntityGrant(grantEntityId, recipientEntityId, "")
 
 	if err != nil {
-		return diag.Errorf("SearchEntityGrants", err)
+		return diag.Errorf("SearchEntityGrants '%v'", err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		data.SetId("")

--- a/fusionauth/resource_fusionauth_entity_grant.go
+++ b/fusionauth/resource_fusionauth_entity_grant.go
@@ -1,0 +1,132 @@
+package fusionauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/FusionAuth/go-client/pkg/fusionauth"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func newEntityGrant() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createEntityGrant,
+		ReadContext:   readEntityGrant,
+		// UpdateContext: updateEntityGrant,
+		DeleteContext: deleteEntityGrant,
+		Schema: map[string]*schema.Schema{
+			"grant_entity_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "The id of the entity that the grant is provided on",
+				ValidateFunc: validation.IsUUID,
+			},
+			"recipient_entity_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "The id of the entity receiving the permission",
+				ValidateFunc: validation.IsUUID,
+			},
+			"data": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Data associated with the grant",
+			},
+		},
+	}
+}
+
+func createEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	grantEntityId := data.Get("grant_entity_id").(string)
+	entityGrant := createEntityGrantFromData(data)
+
+	resp, faErrs, err := client.FAClient.UpsertEntityGrant(grantEntityId, fusionauth.EntityGrantRequest{Grant: entityGrant})
+
+	if err != nil {
+		return diag.Errorf("UpsertEntityGrant err: %v", err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(synthesizeEntityGrantId(grantEntityId, entityGrant.RecipientEntityId))
+
+	return nil
+}
+
+func createEntityGrantFromData(data *schema.ResourceData) fusionauth.EntityGrant {
+	return fusionauth.EntityGrant{
+		// TODO: The API supports granting users this way as well.
+		// Probably should select 1 or the other rather than assuming recipient_
+		RecipientEntityId: data.Get("recipient_entity_id").(string),
+	}
+}
+
+func readEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+
+	grant_entity_id := data.Get("grant_entity_id").(string)
+	recipient_entity_id := data.Get("recipient_entity_id").(string)
+
+	resp, faErrs, err := client.FAClient.RetrieveEntityGrant(grant_entity_id, recipient_entity_id, "")
+
+	if err != nil {
+		return diag.Errorf("SearchEntityGrants", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		data.SetId("")
+		return nil
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return entityGrantToData(&resp.Grant, data)
+}
+
+func synthesizeEntityGrantId(entityId string, recipientEntityId string) string {
+	return fmt.Sprintf("%s::%s", entityId, recipientEntityId)
+}
+
+func entityGrantToData(entityGrant *fusionauth.EntityGrant, data *schema.ResourceData) diag.Diagnostics {
+	data.SetId(synthesizeEntityGrantId(entityGrant.Id, entityGrant.RecipientEntityId))
+	if err := data.Set("grant_entity_id", entityGrant.Id); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("recipient_entity_id", entityGrant.RecipientEntityId); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+// func updateEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+// 	client := i.(Client)
+
+// 	return nil
+// }
+
+func deleteEntityGrant(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+
+	grantEntityId := data.Get("entity_grant_id").(string)
+	recipientEntityId := data.Get("recipient_entity_id").(string)
+
+	resp, faErrs, err := client.FAClient.DeleteEntityGrant(grantEntityId, recipientEntityId, "")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/fusionauth/resource_fusionauth_entity_type.go
+++ b/fusionauth/resource_fusionauth_entity_type.go
@@ -1,0 +1,132 @@
+package fusionauth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/FusionAuth/go-client/pkg/fusionauth"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func newEntityType() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createEntityType,
+		ReadContext:   readEntityType,
+		UpdateContext: updateEntityType,
+		DeleteContext: deleteEntityType,
+		Schema: map[string]*schema.Schema{
+			"entity_type_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The id of the entity type",
+				ValidateFunc: validation.IsUUID,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the entity type",
+			},
+			"data": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "An object that can hold any information about the Group that should be persisted.",
+			},
+		},
+	}
+}
+
+func readEntityType(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+
+	resp, faErrs, err := client.FAClient.RetrieveEntityType(id)
+	if err != nil {
+		return diag.Errorf("RetrieveGroup err: %v", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		data.SetId("")
+		return nil
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	t := resp.EntityType
+	if err := data.Set("name", t.Name); err != nil {
+		return diag.Errorf("group.name: %s", err.Error())
+	}
+	if err := data.Set("data", t.Data); err != nil {
+		return diag.Errorf("group.data: %s", err.Error())
+	}
+
+	return nil
+}
+
+func createEntityType(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	name := data.Get("name").(string)
+
+	var id string
+	if etid, ok := data.GetOk("entity_type_id"); ok {
+		id = etid.(string)
+	}
+
+	resp, faErrs, err := client.FAClient.CreateEntityType(id, fusionauth.EntityTypeRequest{
+		EntityType: fusionauth.EntityType{
+			Name: name,
+		},
+	})
+
+	if err != nil {
+		return diag.Errorf("CreateEntity err: %v", err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(resp.EntityType.Id)
+
+	return nil
+}
+
+func updateEntityType(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+	name := data.Get("name").(string)
+
+	resp, faErrs, err := client.FAClient.UpdateEntityType(id, fusionauth.EntityTypeRequest{
+		EntityType: fusionauth.EntityType{
+			Name: name,
+		},
+	})
+
+	if err != nil {
+		return diag.Errorf("UpdateEntity err: %v", err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func deleteEntityType(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+
+	// Need to determine the behavior when there are existing entities bound to this type
+	resp, faErrs, err := client.FAClient.DeleteEntityType(id)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/fusionauth/resource_fusionauth_entity_type.go
+++ b/fusionauth/resource_fusionauth_entity_type.go
@@ -30,38 +30,6 @@ func newEntityType() *schema.Resource {
 				Required:    true,
 				Description: "The name of the entity type",
 			},
-			// "permission": {
-			// 	Type:     schema.TypeList,
-			// 	Optional: true,
-			// 	Elem: &schema.Resource{
-			// 		Schema: map[string]*schema.Schema{
-			// 			"permissions_id": {
-			// 				Type:         schema.TypeString,
-			// 				Optional:     true,
-			// 				Computed:     true,
-			// 				ForceNew:     true,
-			// 				ValidateFunc: validation.IsUUID,
-			// 				Description:  "The permissions id",
-			// 			},
-			// 			"name": {
-			// 				Type:        schema.TypeString,
-			// 				Required:    true,
-			// 				Description: "The permission name",
-			// 			},
-			// 			"description": {
-			// 				Type:        schema.TypeString,
-			// 				Optional:    true,
-			// 				Description: "The permission description",
-			// 			},
-			// 			"is_default": {
-			// 				Type:        schema.TypeBool,
-			// 				Optional:    true,
-			// 				Computed:    true,
-			// 				Description: "Should the permission be applied by default",
-			// 			},
-			// 		},
-			// 	},
-			// },
 			"data": {
 				Type:        schema.TypeMap,
 				Optional:    true,

--- a/fusionauth/resource_fusionauth_entity_type_permission.go
+++ b/fusionauth/resource_fusionauth_entity_type_permission.go
@@ -50,9 +50,9 @@ func createEntityTypePermission(_ context.Context, data *schema.ResourceData, i 
 
 	entityTypePerm := createEntityTypePermissionFromData(data)
 
-	entityTypeId := data.Get("entity_type_id").(string)
+	entityTypeID := data.Get("entity_type_id").(string)
 
-	resp, faErrs, err := client.FAClient.CreateEntityTypePermission(entityTypeId, "", fusionauth.EntityTypeRequest{
+	resp, faErrs, err := client.FAClient.CreateEntityTypePermission(entityTypeID, "", fusionauth.EntityTypeRequest{
 		Permission: entityTypePerm,
 	})
 
@@ -95,8 +95,8 @@ func entityTypePermissionToData(perm *fusionauth.EntityTypePermission, data *sch
 func readEntityTypePermission(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	// We need to find the permission on the main element
-	entityTypeId := data.Get("entity_type_id").(string)
-	resp, faErrs, err := client.FAClient.RetrieveEntityType(entityTypeId)
+	entityTypeID := data.Get("entity_type_id").(string)
+	resp, faErrs, err := client.FAClient.RetrieveEntityType(entityTypeID)
 	if err != nil {
 		return diag.Errorf("RetrieveEntityType err: %v", err)
 	}
@@ -104,9 +104,9 @@ func readEntityTypePermission(_ context.Context, data *schema.ResourceData, i in
 		return diag.FromErr(err)
 	}
 
-	for _, perm := range resp.EntityType.Permissions {
+	for idx, perm := range resp.EntityType.Permissions {
 		if perm.Id == data.Id() {
-			entityTypePermissionToData(&perm, data)
+			entityTypePermissionToData(&resp.EntityType.Permissions[idx], data)
 			return nil
 		}
 	}
@@ -117,8 +117,8 @@ func readEntityTypePermission(_ context.Context, data *schema.ResourceData, i in
 func updateEntityTypePermission(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	id := data.Id()
-	entityTypeId := data.Get("entity_type_id").(string)
-	resp, faErrs, err := client.FAClient.UpdateEntityTypePermission(entityTypeId, id, fusionauth.EntityTypeRequest{
+	entityTypeID := data.Get("entity_type_id").(string)
+	resp, faErrs, err := client.FAClient.UpdateEntityTypePermission(entityTypeID, id, fusionauth.EntityTypeRequest{
 		Permission: createEntityTypePermissionFromData(data),
 	})
 	if err != nil {

--- a/fusionauth/resource_fusionauth_entity_type_permission.go
+++ b/fusionauth/resource_fusionauth_entity_type_permission.go
@@ -133,9 +133,9 @@ func updateEntityTypePermission(_ context.Context, data *schema.ResourceData, i 
 func deleteEntityTypePermission(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	id := data.Id()
-	entityTypeId := data.Get("entity_type_id").(string)
+	entityTypeID := data.Get("entity_type_id").(string)
 
-	resp, faErrs, err := client.FAClient.DeleteEntityTypePermission(entityTypeId, id)
+	resp, faErrs, err := client.FAClient.DeleteEntityTypePermission(entityTypeID, id)
 	if err != nil {
 		return diag.Errorf("DeleteEntityTypePermission err: %v", err)
 	}

--- a/fusionauth/resource_fusionauth_entity_type_permission.go
+++ b/fusionauth/resource_fusionauth_entity_type_permission.go
@@ -1,0 +1,149 @@
+package fusionauth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/FusionAuth/go-client/pkg/fusionauth"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func newEntityTypePermission() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createEntityTypePermission,
+		ReadContext:   readEntityTypePermission,
+		UpdateContext: updateEntityTypePermission,
+		DeleteContext: deleteEntityTypePermission,
+		Schema: map[string]*schema.Schema{
+			"entity_type_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "The id of the entity type this permission is for",
+				ValidateFunc: validation.IsUUID,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The name of the permission",
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The long form description of the permission",
+			},
+			"is_default": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether the permission is assigned by default during grants",
+			},
+		},
+	}
+}
+
+func createEntityTypePermission(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+
+	entityTypePerm := createEntityTypePermissionFromData(data)
+
+	entityTypeId := data.Get("entity_type_id").(string)
+
+	resp, faErrs, err := client.FAClient.CreateEntityTypePermission(entityTypeId, "", fusionauth.EntityTypeRequest{
+		Permission: entityTypePerm,
+	})
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return entityTypePermissionToData(&resp.Permission, data)
+}
+
+func createEntityTypePermissionFromData(data *schema.ResourceData) fusionauth.EntityTypePermission {
+	var description string
+	if v, ok := data.GetOk("description"); ok {
+		description = v.(string)
+	}
+	return fusionauth.EntityTypePermission{
+		Name:        data.Get("name").(string),
+		Description: description,
+		IsDefault:   data.Get("is_default").(bool),
+	}
+}
+
+func entityTypePermissionToData(perm *fusionauth.EntityTypePermission, data *schema.ResourceData) diag.Diagnostics {
+	data.SetId(perm.Id)
+	if err := data.Set("name", perm.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("description", perm.Description); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("is_default", perm.IsDefault); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func readEntityTypePermission(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	// We need to find the permission on the main element
+	entityTypeId := data.Get("entity_type_id").(string)
+	resp, faErrs, err := client.FAClient.RetrieveEntityType(entityTypeId)
+	if err != nil {
+		return diag.Errorf("RetrieveEntityType err: %v", err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	for _, perm := range resp.EntityType.Permissions {
+		if perm.Id == data.Id() {
+			entityTypePermissionToData(&perm, data)
+			return nil
+		}
+	}
+	data.SetId("")
+	return nil
+}
+
+func updateEntityTypePermission(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+	entityTypeId := data.Get("entity_type_id").(string)
+	resp, faErrs, err := client.FAClient.UpdateEntityTypePermission(entityTypeId, id, fusionauth.EntityTypeRequest{
+		Permission: createEntityTypePermissionFromData(data),
+	})
+	if err != nil {
+		return diag.Errorf("UpdateEntityTypePermission err: %v", err)
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func deleteEntityTypePermission(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+	id := data.Id()
+	entityTypeId := data.Get("entity_type_id").(string)
+
+	resp, faErrs, err := client.FAClient.DeleteEntityTypePermission(entityTypeId, id)
+	if err != nil {
+		return diag.Errorf("DeleteEntityTypePermission err: %v", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if err := checkResponse(resp.StatusCode, faErrs); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -98,12 +98,14 @@ func newTenant() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem:     newFailedAuthenticationConfiguration(),
 			},
 			"family_configuration": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem:     newFamilyConfiguration(),
 			},
 			"form_configuration": {
@@ -203,6 +205,7 @@ func newTenant() *schema.Resource {
 			},
 			"maximum_password_age": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -224,6 +227,7 @@ func newTenant() *schema.Resource {
 			},
 			"minimum_password_age": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -330,6 +334,7 @@ func newTenant() *schema.Resource {
 			},
 			"password_encryption_configuration": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -365,6 +370,7 @@ func newTenant() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem:     newPasswordValidationRules(),
 			},
 			"theme_id": {
@@ -375,6 +381,7 @@ func newTenant() *schema.Resource {
 			},
 			"user_delete_policy": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem: &schema.Resource{


### PR DESCRIPTION
Hello,

At S5 Stratos, we are evaluating fusionauth, but one of our specific use cases is the ability to model entities.
This is a PR that adds support for entity types, entities, and entity grants.

Additionally, wrt. to acceptance tests, there aren't any, specifically because it was unclear to us whether that is something that is desirable when entities are only supported in the non-community editions.
This is something we are definitely open to adding.

The only unrelated change is that I added Computed: true to some of the optional fields so that terraform did not continually flag changes.
