### PR TITLE
Set properties that fusionauth auto-populates to Computed

### DIFF
--- a/fusionauth/resource_fusionauth_application.go
+++ b/fusionauth/resource_fusionauth_application.go
@@ -97,6 +97,7 @@ func newApplication() *schema.Resource {
 				MaxItems: 1,
 				Elem:     newJWTConfiguration(),
 				Optional: true,
+				Computed: true,
 			},
 			"lambda_configuration": {
 				Type:       schema.TypeList,
@@ -128,6 +129,7 @@ func newApplication() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allow_token_refresh": {
@@ -184,12 +186,14 @@ func newApplication() *schema.Resource {
 				MaxItems: 1,
 				Elem:     newOAuthConfiguration(),
 				Optional: true,
+				Computed: true,
 			},
 			"registration_configuration": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem:     newRegistrationConfiguration(),
 				Optional: true,
+				Computed: true,
 			},
 			"passwordless_configuration_enabled": {
 				Type:        schema.TypeBool,
@@ -201,6 +205,7 @@ func newApplication() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"unverified_enabled": {

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -98,12 +98,14 @@ func newTenant() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem:     newFailedAuthenticationConfiguration(),
 			},
 			"family_configuration": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem:     newFamilyConfiguration(),
 			},
 			"form_configuration": {
@@ -203,6 +205,7 @@ func newTenant() *schema.Resource {
 			},
 			"maximum_password_age": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -224,6 +227,7 @@ func newTenant() *schema.Resource {
 			},
 			"minimum_password_age": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -330,6 +334,7 @@ func newTenant() *schema.Resource {
 			},
 			"password_encryption_configuration": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -365,6 +370,7 @@ func newTenant() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem:     newPasswordValidationRules(),
 			},
 			"theme_id": {
@@ -375,6 +381,7 @@ func newTenant() *schema.Resource {
 			},
 			"user_delete_policy": {
 				Optional: true,
+				Computed: true,
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Elem: &schema.Resource{


### PR DESCRIPTION
As per ending discussion in https://github.com/gpsinsight/terraform-provider-fusionauth/pull/82 this sets optional poperties to computed to suppress change detection.