### PR TITLE
bugfix(tenant): enables support for 3rd-party password encryptor plugins at the tenant level

### DIFF
--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -342,7 +342,7 @@ func newTenant() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "salted-pbkdf2-hmac-sha256",
-							ValidateFunc: validation.StringInSlice([]string{
+							ValidateDiagFunc: WarnStringInSlice([]string{
 								"salted-md5",
 								"salted-sha256",
 								"salted-hmac-sha256",


### PR DESCRIPTION
Enables support at the _tenant level_ for setting `encryption_scheme` to a custom-built encryptor.

Refer:
- https://fusionauth.io/docs/v1/tech/plugins/custom-password-hashing/