### PR TITLE
fix: tenant webhook event name typo

### DIFF
--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -107,7 +107,7 @@ func newTenant() *schema.Resource {
 								"user.registration.update.complete",
 								"user.registration.verified",
 								"user.two-factor.method.add",
-								"user.two-factor-method.remove",
+								"user.two-factor.method.remove",
 								"user.update",
 								"user.update.complete",
 							}, false),


### PR DESCRIPTION
The FusionAuth doco for the Tenant API uses "user.two-factor-method.remove" instead of the correct name "user.two-factor.method.remove", resulting in API errors if its use is attempted. The PR corrects the schema reference to the incorrect name.

See also: https://github.com/FusionAuth/fusionauth-site/pull/1206