### PR TITLE
Fix webhook event typo

### DIFF
--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -107,7 +107,7 @@ func newTenant() *schema.Resource {
 								"user.registration.update.complete",
 								"user.registration.verified",
 								"user.two-factor.method.add",
-								"user.two-factor-method.remove",
+								"user.two-factor.method.remove",
 								"user.update",
 								"user.update.complete",
 							}, false),


### PR DESCRIPTION
There is a typo in the `user.two-factor.method.remove` webhook event. 

When I updated the list of events in PR #104 I [noticed that there were two entries](https://github.com/gpsinsight/terraform-provider-fusionauth/pull/104/files#r766261481) for this event... I didn't realise that the two entries were in fact different  and I removed the wrong one 😞 