### PR TITLE
Add `kid` attribute to key resource.

### DIFF
--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -1,6 +1,6 @@
 # Key Resource
 
-Cryptographic keys are used in signing and verifying JWTs and verifying responses for third party identity providers. It is more likely you will interact with keys using the FusionAuth UI in the Key Master menu. 
+Cryptographic keys are used in signing and verifying JWTs and verifying responses for third party identity providers. It is more likely you will interact with keys using the FusionAuth UI in the Key Master menu.
 
 [Keys API](https://fusionauth.io/docs/v1/tech/apis/keys)
 
@@ -28,4 +28,10 @@ resource "fusionauth_key" "admin_id" {
     - `HS384` - HMAC using SHA-384 hash algorithm
     - `HS512` - HMAC using SHA-512 hash algorithm
 * `name` - (Required) The name of the Key.
-* `length` - (Optional) 
+* `length` - (Optional)
+
+## Attribute Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `kid` - The id used in the JWT header to identify the key used to generate the signature

--- a/fusionauth/resource_fusionauth_key.go
+++ b/fusionauth/resource_fusionauth_key.go
@@ -55,6 +55,11 @@ func newKey() *schema.Resource {
 				ForceNew:    true,
 				Description: "The length of the RSA or EC certificate. This field is required when generating RSA key types.",
 			},
+			"kid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id used in the JWT header to identify the key used to generate the signature",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -91,11 +96,7 @@ func createKey(_ context.Context, data *schema.ResourceData, i interface{}) diag
 	}
 
 	data.SetId(resp.Key.Id)
-	if err := data.Set("key_id", resp.Key.Id); err != nil {
-		return diag.Errorf("key.key_id: %s", err.Error())
-	}
-
-	return nil
+	return buildResourceDataFromKey(data, resp.Key)
 }
 
 func buildResourceDataFromKey(data *schema.ResourceData, res fusionauth.Key) diag.Diagnostics {
@@ -110,6 +111,9 @@ func buildResourceDataFromKey(data *schema.ResourceData, res fusionauth.Key) dia
 	}
 	if err := data.Set("length", res.Length); err != nil {
 		return diag.Errorf("key.length: %s", err.Error())
+	}
+	if err := data.Set("kid", res.Kid); err != nil {
+		return diag.Errorf("key.kid: %s", err.Error())
 	}
 
 	return nil

--- a/fusionauth/resource_fusionauth_key_test.go
+++ b/fusionauth/resource_fusionauth_key_test.go
@@ -120,6 +120,7 @@ func testKeyAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "name", fmt.Sprintf("test-acc %s", resourceName)),
 		resource.TestCheckResourceAttr(tfResourcePath, "algorithm", string(algorithm)),
 		resource.TestCheckResourceAttr(tfResourcePath, "length", fmt.Sprintf("%d", length)),
+		resource.TestCheckResourceAttrSet(tfResourcePath, "kid"),
 	}
 
 	if len(extraFuncs) > 0 {


### PR DESCRIPTION
This PR adds `kid` as an attribute of the key resource. 

The key resource only has a few arguments, but attributes such as the `kid` can be read and exported once the key has been created.