### PR TITLE
Bugfix/fusionauth entity set tenant id in requests

### DIFF
--- a/fusionauth/client.go
+++ b/fusionauth/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Client struct {
-	FAClient *fusionauth.FusionAuthClient
+	FAClient fusionauth.FusionAuthClient
 	Host     string
 	APIKey   string
 }
@@ -35,7 +35,7 @@ func configureClient(_ context.Context, data *schema.ResourceData) (client inter
 	client = Client{
 		Host:   host,
 		APIKey: apiKey,
-		FAClient: fusionauth.NewClient(
+		FAClient: *fusionauth.NewClient(
 			&http.Client{
 				Timeout: time.Second * 30,
 			},

--- a/fusionauth/helpers.go
+++ b/fusionauth/helpers.go
@@ -157,3 +157,21 @@ func intMapToStringMap(intMap map[string]interface{}) map[string]string {
 
 	return m
 }
+
+// clientTenantIDOverride takes in the client and the data. As long as the
+// resource has a tenant_id attribute set, it will override the client's tenant
+// id until the revert function is called.
+func clientTenantIDOverride(client *Client, data *schema.ResourceData) (revert func()) {
+	if tid := data.Get("tenant_id").(string); tid != "" {
+		oldTenantID := client.FAClient.TenantId
+
+		client.FAClient.TenantId = tid
+		return func() {
+			client.FAClient.TenantId = oldTenantID
+		}
+	}
+
+	return func() {
+		// nothing to revert here...
+	}
+}

--- a/fusionauth/resource_fusionauth_generic_connector.go
+++ b/fusionauth/resource_fusionauth_generic_connector.go
@@ -111,7 +111,7 @@ func buildGenericConnector(data *schema.ResourceData) fusionauth.GenericConnecto
 func createGenericConnector(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	connector := buildGenericConnector(data)
-	resp, faErrs, err := CreateConnector(*client.FAClient, connector.Id, GenericConnectorRequest{Connector: connector})
+	resp, faErrs, err := CreateConnector(client.FAClient, connector.Id, GenericConnectorRequest{Connector: connector})
 	if err != nil {
 		return diag.Errorf("CreateGenericConnector err: %v", err)
 	}
@@ -127,7 +127,7 @@ func readGenericConnector(_ context.Context, data *schema.ResourceData, i interf
 	client := i.(Client)
 	id := data.Id()
 
-	resp, faErrs, err := RetrieveConnector(*client.FAClient, id)
+	resp, faErrs, err := RetrieveConnector(client.FAClient, id)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -179,7 +179,7 @@ func updateGenericConnector(_ context.Context, data *schema.ResourceData, i inte
 	client := i.(Client)
 	connector := buildGenericConnector(data)
 
-	resp, faErrs, err := UpdateConnector(*client.FAClient, data.Id(), GenericConnectorRequest{Connector: connector})
+	resp, faErrs, err := UpdateConnector(client.FAClient, data.Id(), GenericConnectorRequest{Connector: connector})
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Fixes #118.

### Tenant ID Concurrency Bug
One thing I noticed while dealing with this is the tenant id kept changing, and I realized that we were running into concurrency issues around the Tenant ID when multiple FusionAuth API requests are being fired to the binary. I've patched that in this, but happy to move out to a different patch set if required.

By passing the client by value, downstream functions will receive a copy of the "default" client config rather than the reference value, which is why the tenant id could be munged over multiple requests, or in-flight requests with different tenant ids.

The following image shows the underlying data with this patch:
![image](https://user-images.githubusercontent.com/6119549/166609864-6daf1775-be22-4c2b-a788-089f1c4bfd40.png)

Previously, I was getting the client incoming with a tenant id set from another entity read request (req#1), which would lead to the current request (req#2) setting the `client.oldTenantId` = `(req#1 changed)client.FAClient.TenantId`. Leaving the client having a tenant id set as default on "reverting" the change via the defer'd  function:
```go
defer func(){
	client.FAClient.TenantId = oldTenantID 
}()`.
```

The only danger now is the underlying *http.Client within the FusionAuth client, but I think that's okay compared to sending requests to non-intended tenants?

_Hopefully_ this analysis makes sense!