### PR TITLE
feature(form): adds support for `fusionauth_form` as a data source.

### DIFF
--- a/docs/data-sources/form.md
+++ b/docs/data-sources/form.md
@@ -1,0 +1,33 @@
+# Form Resource
+
+A FusionAuth Form is a customizable object that contains one-to-many ordered steps. Each step is comprised of one or more Form Fields.
+
+[Forms API](https://fusionauth.io/docs/v1/tech/apis/forms)
+
+## Example Usage
+
+```hcl
+data "fusionauth_form" "default" {
+    name = "Default User Self Service provided by FusionAuth"
+}
+```
+
+## Argument Reference
+
+* `form_id` - (Optional) The unique id of the Form. Either `form_id` or `name` must be specified.
+* `name` - (Optional) The name of the Form. Either `form_id` or `name` must be specified.
+
+## Attributes Reference
+
+All the argument attributes are also exported as result attributes.
+
+The following additional attributes are exported:
+
+* `id` - The unique Id of the Form.
+* `data` - An object that can hold any information about the Form that should be persisted.
+* `name` - The unique name of the Form.
+* `steps` - An ordered list of objects containing one or more Form Fields.
+* `type` - The form type. The possible values are:
+    * `registration` - This form will be used for self service registration.
+    * `adminRegistration` - This form be used to customize the add and edit User Registration form in the FusionAuth UI.
+    * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI.

--- a/fusionauth/datasource_fusionauth_form.go
+++ b/fusionauth/datasource_fusionauth_form.go
@@ -1,0 +1,112 @@
+package fusionauth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/FusionAuth/go-client/pkg/fusionauth"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceForm() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFormRead,
+		Schema: map[string]*schema.Schema{
+			"form_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"form_id", "name"},
+				Description:  "The unique Id of the Form.",
+				ValidateFunc: validation.IsUUID,
+			},
+			"data": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "An object that can hold any information about the Form that should be persisted.",
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"form_id", "name"},
+				Description:  "The unique name of the Form.",
+			},
+			"steps": {
+				Type:        schema.TypeList,
+				Description: "An ordered list of objects containing one or more Form Fields. A Form must have at least one step defined.",
+				MinItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fields": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							MinItems:    1,
+							Required:    true,
+							Description: "An ordered list of Form Field Ids assigned to this step.",
+						},
+					},
+				},
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of form being created, a form type cannot be changed after the form has been created.",
+				Default:     "registration",
+				ForceNew:    true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"registration",
+					"adminRegistration",
+					"adminUser",
+				}, false),
+			},
+		},
+	}
+}
+
+func dataSourceFormRead(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+
+	var searchTerm string
+	var res *fusionauth.FormResponse
+	var err error
+
+	// Either `form_id` or `name` are guaranteed to be set
+	if entityID, ok := data.GetOk("form_id"); ok {
+		searchTerm = entityID.(string)
+		res, err = client.FAClient.RetrieveForm(searchTerm)
+	} else {
+		searchTerm = data.Get("name").(string)
+		res, err = client.FAClient.RetrieveForms()
+	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if res.StatusCode == http.StatusNotFound {
+		return diag.Errorf("couldn't find form '%s'", searchTerm)
+	}
+	if err := checkResponse(res.StatusCode, nil); err != nil {
+		return diag.FromErr(err)
+	}
+
+	foundEntity := res.Form
+	if len(res.Forms) > 0 {
+		// search based on name
+		var found = false
+		for _, entity := range res.Forms {
+			if entity.Name == searchTerm {
+				found = true
+				foundEntity = entity
+				break
+			}
+		}
+		if !found {
+			return diag.Errorf("couldn't find form with name '%s'", searchTerm)
+		}
+	}
+
+	data.SetId(foundEntity.Id)
+	return buildResourceDataFromForm(data, foundEntity)
+}

--- a/fusionauth/provider.go
+++ b/fusionauth/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"fusionauth_lambda":           dataSourceLambda(),
 			"fusionauth_application":      dataSourceApplication(),
+			"fusionauth_form":             dataSourceForm(),
 			"fusionauth_tenant":           dataSourceTenant(),
 			"fusionauth_application_role": dataSourceApplicationRole(),
 			"fusionauth_idp":              dataSourceIDP(),

--- a/fusionauth/resource_fusionauth_form.go
+++ b/fusionauth/resource_fusionauth_form.go
@@ -162,6 +162,9 @@ func buildForm(data *schema.ResourceData) fusionauth.Form {
 }
 
 func buildResourceDataFromForm(data *schema.ResourceData, f fusionauth.Form) diag.Diagnostics {
+	if err := data.Set("form_id", f.Id); err != nil {
+		return diag.Errorf("form.form_id: %s", err.Error())
+	}
 	if err := data.Set("data", f.Data); err != nil {
 		return diag.Errorf("form.data: %s", err.Error())
 	}


### PR DESCRIPTION
Silly little thing I've come across where applications need to have a self-service form set in order for users to configure their own MFA, but the default Form IDs are unique (i.e. not the same) across deployments...