### PR TITLE
feat(user): adds support for two factor method id.

### DIFF
--- a/fusionauth/resource_fusionauth_user.go
+++ b/fusionauth/resource_fusionauth_user.go
@@ -249,6 +249,7 @@ func userResponseToData(data *schema.ResourceData, resp *fusionauth.UserResponse
 		}
 
 		twoFactorMethodsData[i] = map[string]interface{}{
+			"two_factor_method_id":      twoFactorMethod.Id,
 			"authenticator_algorithm":   twoFactorMethod.Authenticator.Algorithm,
 			"authenticator_code_length": twoFactorMethod.Authenticator.CodeLength,
 			"authenticator_time_step":   twoFactorMethod.Authenticator.TimeStep,
@@ -290,6 +291,7 @@ func dataToTwoFactorMethods(data *schema.ResourceData) (twoFactorMethods []fusio
 			})
 		} else {
 			twoFactorMethods[i] = fusionauth.TwoFactorMethod{
+				Id: twoFactorMethod["two_factor_method_id"].(string),
 				Authenticator: fusionauth.AuthenticatorConfiguration{
 					Algorithm:  fusionauth.TOTPAlgorithm(twoFactorMethod["authenticator_algorithm"].(string)),
 					CodeLength: twoFactorMethod["authenticator_code_length"].(int),

--- a/fusionauth/resource_fusionauth_user_schema.go
+++ b/fusionauth/resource_fusionauth_user_schema.go
@@ -157,6 +157,11 @@ func userSchemaV1() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"two_factor_method_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique Id of the method.",
+						},
 						"authenticator_algorithm": {
 							Type:     schema.TypeString,
 							Optional: true,


### PR DESCRIPTION
Turns out `user.twoFactor.methods[x].id` is required to update a user with an `authenticator` two factor method configured.

The ID is used internally to track the lifecycle of the provided authentication method so FusionAuth doesn't have to return `HTTP 400` when a secret isn't provided.