### PR TITLE
[feature] add user action id attribute to user action resource

### DIFF
--- a/docs/resources/user_action.md
+++ b/docs/resources/user_action.md
@@ -15,6 +15,7 @@ resource "fusionauth_user_action" "example" {
 
 ## Argument Reference
 * `name` - (Required) The name of this User Action.
+* `user_action_id` - (Optional) The id of this User Action.
 * `cancel_email_template_id` - (Optional) The Id of the Email Template that is used when User Actions are canceled.
 * `end_email_template_id` - (Optional) The Id of the Email Template that is used when User Actions expired automatically (end).
 * `include_email_in_event_json` - (Optional) Whether to include the email information in the JSON that is sent to the Webhook when a user action is taken.

--- a/fusionauth/helpers.go
+++ b/fusionauth/helpers.go
@@ -118,9 +118,9 @@ func mapStringInterfaceToJSONString(in map[string]interface{}) (out string, diag
 // terraform state.
 //
 // Note:
-// - This performs simple top level loading and returning a build up of errors.
-// - Any sub-objects/maps/lists requiring specific ordering will need to be
-//   handled manually.
+//   - This performs simple top level loading and returning a build up of errors.
+//   - Any sub-objects/maps/lists requiring specific ordering will need to be
+//     handled manually.
 func setResourceData(resource string, data *schema.ResourceData, dataMapping map[string]interface{}) (diags diag.Diagnostics) {
 	for k, v := range dataMapping {
 		switch k {

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -380,21 +380,21 @@ func testAccTenantResourceBasicConfig(
 // tenant.
 //
 // Note:
-// - A bug in the terraform SDK means defaults configured for TypeList/TypeSet
-//   schemas aren't applied unless the top level object is defined in the
-//   config, for example, you have to explicitly add `minimum_password_age {}`
-//   to get the defaults to propagate down into the object's properties.
-//   Refer: https://github.com/hashicorp/terraform-plugin-sdk/issues/142
-// - `form_configuration.admin_user_form_id` is commented out as it requires a
-//   paid edition of fusionauth.
-// - `multi_factor_configuration.email.enabled` is set to false, as it requires
-//   a paid edition of fusionauth.
-// - `multi_factor_configuration.sms.enabled` is set to false, as it requires
-//   a paid edition of fusionauth.
-// - `password_validation_rules.breach_detection.enabled` is set to false, as
-//   it requires a paid edition of fusionauth.
-// - `username_configuration.unique.enabled` is set to false, as it requires a
-//   paid edition of fusionauth.
+//   - A bug in the terraform SDK means defaults configured for TypeList/TypeSet
+//     schemas aren't applied unless the top level object is defined in the
+//     config, for example, you have to explicitly add `minimum_password_age {}`
+//     to get the defaults to propagate down into the object's properties.
+//     Refer: https://github.com/hashicorp/terraform-plugin-sdk/issues/142
+//   - `form_configuration.admin_user_form_id` is commented out as it requires a
+//     paid edition of fusionauth.
+//   - `multi_factor_configuration.email.enabled` is set to false, as it requires
+//     a paid edition of fusionauth.
+//   - `multi_factor_configuration.sms.enabled` is set to false, as it requires
+//     a paid edition of fusionauth.
+//   - `password_validation_rules.breach_detection.enabled` is set to false, as
+//     it requires a paid edition of fusionauth.
+//   - `username_configuration.unique.enabled` is set to false, as it requires a
+//     paid edition of fusionauth.
 func testAccTenantResourceConfig(
 	resourceName string,
 	themeKey string,

--- a/fusionauth/resource_fusionauth_user_action.go
+++ b/fusionauth/resource_fusionauth_user_action.go
@@ -22,6 +22,13 @@ func resourceUserAction() *schema.Resource {
 				Required:    true,
 				Description: "The name of this User Action.",
 			},
+			"user_action_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The id of this User Action.",
+				ValidateFunc: validation.IsUUID,
+			},
 			"cancel_email_template_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -112,6 +119,9 @@ func buildUserAction(data *schema.ResourceData) fusionauth.UserAction {
 		Name: data.Get("name").(string),
 	}
 
+	if d, ok := data.GetOk("user_action_id"); ok {
+		ua.Id = d.(string)
+	}
 	if d, ok := data.GetOk("cancel_email_template_id"); ok {
 		ua.CancelEmailTemplateId = d.(string)
 	}
@@ -187,6 +197,9 @@ func readUserAction(_ context.Context, data *schema.ResourceData, i interface{})
 
 	if err := data.Set("name", resp.UserAction.Name); err != nil {
 		return diag.Errorf("user_action.name: %s", err.Error())
+	}
+	if err := data.Set("user_action_id", resp.UserAction.Id); err != nil {
+		return diag.Errorf("user_action.id: %s", err.Error())
 	}
 	if err := data.Set("cancel_email_template_id", resp.UserAction.CancelEmailTemplateId); err != nil {
 		return diag.Errorf("user_action.cancel_email_template_id: %s", err.Error())


### PR DESCRIPTION
### Description

We want to create the user action with an id that we provide. The terraform provider does not currently allow this: [Terraform Registry](https://registry.terraform.io/providers/gpsinsight/fusionauth/latest/docs/resources/user_action) 

###Tasks

- [x] Update the user action terraform resource to allow passing of id

### Out of scope

- adding test for the whole file resource_fusion_user_action 
