### PR TITLE
Updates to support fusionauth 1.40.x

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -165,7 +165,7 @@ resource "fusionauth_application" "Forum" {
     - `issuer` - (Required) The issuer that identifies the service provider and allows FusionAuth to load the correct Application and SAML configuration. If you don’t know the issuer, you can often times put in anything here and FusionAuth will display an error message with the issuer from the service provider when you test the SAML login.
     - `key_id` - (Optional) The id of the Key used to sign the SAML response. If you do not specify this property, FusionAuth will create a new key and associate it with this Application.
     - `logout` - (Optional)
-        * `behavior` - (Optional) This configuration is functionally equivalent to the Logout Behavior found in the OAuth2 configuration. 
+        * `behavior` - (Optional) This configuration is functionally equivalent to the Logout Behavior found in the OAuth2 configuration.
         * `default_verification_key_id` - (Optional) The unique Id of the Key used to verify the signature if the public key cannot be determined by the KeyInfo element when using POST bindings, or the key used to verify the signature when using HTTP Redirect bindings.
         * `key_id` - (Optional) The unique Id of the Key used to sign the SAML Logout response.
         * `require_signed_requests` - (Optional) Set this parameter equal to true to require the SAML v2 Service Provider to sign the Logout request. When this value is true all Logout requests missing a signature will be rejected.
@@ -182,7 +182,6 @@ resource "fusionauth_application" "Forum" {
 * `theme_id` - (Optional) The unique Id of the theme to be used to style the login page and other end user templates.
 * `verification_email_template_id` - (Optional) The Id of the Email Template that is used to send the Registration Verification emails to users. If the verifyRegistration field is true this field is required.
 * `verify_registration` - (Optional) Whether or not registrations to this Application may be verified. When this is set to true the verificationEmailTemplateId parameter is also required.
-* `webhook_ids` - (Optional) An array of Webhook Ids. For Webhooks that are not already configured for All Applications, specifying an Id on this request will indicate the associated Webhook should handle events for this application.
 * `email_configuration` - (Optional)
     - `email_verification_template_id` - (Optional) The Id of the Email Template used to send emails to users to verify that their email address is valid. When configured, this value will take precedence over the same configuration from the Tenant when an application context is known.
     - `email_update_template_id` - (Optional) The Id of the Email Template used to send emails to users when their email address is updated. When configured, this value will take precedence over the same configuration from the Tenant when an application context is known.

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -8,10 +8,6 @@ A FusionAuth Webhook is intended to consume JSON events emitted by FusionAuth. C
 
 ```hcl
 resource "fusionauth_webhook" "example" {
-  application_ids = [
-    "00000000-0000-0000-0000-000000000003",
-    fusionauth_application.example.id
-  ]
   connect_timeout = 1000
   description     = "The standard game Webhook"
   events_enabled {
@@ -31,7 +27,6 @@ resource "fusionauth_webhook" "example" {
 ```
 
 ## Argument Reference
-* `application_ids` - (Optional) The Ids of the Applications that this Webhook should be associated with. If no Ids are specified and the global field is false, this Webhook will not be used.
 * `connect_timeout` - (Required) The connection timeout in milliseconds used when FusionAuth sends events to the Webhook.
 * `description` - (Optional) A description of the Webhook. This is used for display purposes only.
 * `events_enabled` - (Optional) A mapping for the events that are enabled for this Webhook.

--- a/fusionauth/resource_fusionauth_application.go
+++ b/fusionauth/resource_fusionauth_application.go
@@ -270,12 +270,6 @@ func newApplication() *schema.Resource {
 				Default:     false,
 				Description: "Whether or not registrations to this Application may be verified. When this is set to true the verificationEmailTemplateId parameter is also required.",
 			},
-			"webhook_ids": {
-				Type:        schema.TypeSet,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
-				Description: "An array of Webhook Ids. For Webhooks that are not already configured for All Applications, specifying an Id on this request will indicate the associated Webhook should handle events for this application.",
-			},
 			"email_configuration": {
 				Type:       schema.TypeList,
 				MaxItems:   1,

--- a/fusionauth/resource_fusionauth_application_crud.go
+++ b/fusionauth/resource_fusionauth_application_crud.go
@@ -21,10 +21,6 @@ func createApplication(_ context.Context, data *schema.ResourceData, i interface
 		client.FAClient.TenantId = oldTenantID
 	}()
 
-	if hooks, ok := data.GetOk("webhooks"); ok {
-		ar.WebhookIds = hooks.([]string)
-	}
-
 	var aid string
 	if a, ok := data.GetOk("application_id"); ok {
 		aid = a.(string)
@@ -66,10 +62,6 @@ func updateApplication(_ context.Context, data *schema.ResourceData, i interface
 	client := i.(Client)
 	ar := fusionauth.ApplicationRequest{
 		Application: buildApplication(data),
-	}
-
-	if hooks, ok := data.GetOk("webhooks"); ok {
-		ar.WebhookIds = hooks.([]string)
 	}
 
 	resp, faErrs, err := client.FAClient.UpdateApplication(data.Id(), ar)

--- a/fusionauth/resource_fusionauth_webhook.go
+++ b/fusionauth/resource_fusionauth_webhook.go
@@ -16,12 +16,6 @@ func newWebhook() *schema.Resource {
 		UpdateContext: updateWebhook,
 		DeleteContext: deleteWebhook,
 		Schema: map[string]*schema.Schema{
-			"application_ids": {
-				Type:        schema.TypeSet,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
-				Description: "The Ids of the Applications that this Webhook should be associated with. If no Ids are specified and the global field is false, this Webhook will not be used.",
-			},
 			"connect_timeout": {
 				Type:        schema.TypeInt,
 				Required:    true,
@@ -278,7 +272,6 @@ func newWebhook() *schema.Resource {
 
 func buildWebhook(data *schema.ResourceData) fusionauth.Webhook {
 	wh := fusionauth.Webhook{
-		ApplicationIds: handleStringSlice("application_ids", data),
 		ConnectTimeout: data.Get("connect_timeout").(int),
 		Description:    data.Get("description").(string),
 		EventsEnabled:  buildEventsEnabled("events_enabled", data),
@@ -377,9 +370,6 @@ func readWebhook(_ context.Context, data *schema.ResourceData, i interface{}) di
 	}
 
 	l := resp.Webhook
-	if err := data.Set("application_ids", l.ApplicationIds); err != nil {
-		return diag.Errorf("webhook.application_ids: %s", err.Error())
-	}
 	if err := data.Set("connect_timeout", l.ConnectTimeout); err != nil {
 		return diag.Errorf("webhook.connect_timeout: %s", err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gpsinsight/terraform-provider-fusionauth
 go 1.18
 
 require (
-	github.com/FusionAuth/go-client v0.0.0-20220429153148-63e95adfac4e
+	github.com/FusionAuth/go-client v0.0.0-20220927000356-028dacca67f0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/FusionAuth/go-client v0.0.0-20220429153148-63e95adfac4e h1:1GkB6QE01BlB7+OCwWBBiUM/xBqMA5vpFgr7C/fF2ck=
 github.com/FusionAuth/go-client v0.0.0-20220429153148-63e95adfac4e/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
+github.com/FusionAuth/go-client v0.0.0-20220927000356-028dacca67f0 h1:gV0qAy8Su8r4pOJxj6uZ/qqycVhW6uU8tUMSkOcgr+s=
+github.com/FusionAuth/go-client v0.0.0-20220927000356-028dacca67f0/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=


### PR DESCRIPTION
Partially resolves #144 

This updates the go client which is needed due to Content-Type header changes. I have also removed account/webhook relationships as these have been removed from FusionAuth - they need to be added back to the tenant.