### PR TITLE
fix(user_action): Pass the user action id to the FAClient

### DIFF
--- a/fusionauth/resource_fusionauth_user_action.go
+++ b/fusionauth/resource_fusionauth_user_action.go
@@ -164,9 +164,10 @@ func buildUserAction(data *schema.ResourceData) fusionauth.UserAction {
 
 func createUserAction(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
+	userAction := buildUserAction(data)
 
-	resp, faErrs, err := client.FAClient.CreateUserAction("", fusionauth.UserActionRequest{
-		UserAction: buildUserAction(data),
+	resp, faErrs, err := client.FAClient.CreateUserAction(userAction.Id, fusionauth.UserActionRequest{
+		UserAction: userAction,
 	})
 
 	if err != nil {


### PR DESCRIPTION
We recently implemented the ability to provide the `user_action_id` when creating a user action. However, we forgot to pass the id to the FusionAuth client.
