### PR TITLE
fusionauth_email: Make default_from_name and from_email optional

### DIFF
--- a/docs/resources/email.md
+++ b/docs/resources/email.md
@@ -20,11 +20,11 @@ resource "fusionauth_email" "HelloWorld" {
 ## Argument Reference
 
 * `email_id` - (Optional) The Id to use for the new Email Template. If not specified a secure random UUID will be generated.
-* `default_from_name` - (Required) The default From Name used when sending emails. If not provided, and a localized value cannot be determined, the default value for the tenant will be used. This is the display name part of the email address ( i.e. Jared Dunn <jared@piedpiper.com>).
+* `default_from_name` - (Optional) The default From Name used when sending emails. If not provided, and a localized value cannot be determined, the default value for the tenant will be used. This is the display name part of the email address ( i.e. Jared Dunn <jared@piedpiper.com>).
 * `default_html_template` - (Required) The default HTML Email Template.
 * `default_subject` - (Required) The default Subject used when sending emails.
 * `default_text_template` - (Required) The default Text Email Template.
-* `from_email` - (Required) The email address that this email will be sent from. If not provided, the default value for the tenant will be used. This is the address part email address (i.e. Jared Dunn <jared@piedpiper.com>).
+* `from_email` - (Optional) The email address that this email will be sent from. If not provided, the default value for the tenant will be used. This is the address part email address (i.e. Jared Dunn <jared@piedpiper.com>).
 * `localized_from_names` - (Optional) The From Name used when sending emails to users who speak other languages. This overrides the default From Name based on the user’s list of preferred languages.
 * `localized_html_templates` - (Optional) The HTML Email Template used when sending emails to users who speak other languages. This overrides the default HTML Email Template based on the user’s list of preferred languages.
 * `localized_subjects` - (Optional) The Subject used when sending emails to users who speak other languages. This overrides the default Subject based on the user’s list of preferred languages.

--- a/fusionauth/resource_fusionauth_email.go
+++ b/fusionauth/resource_fusionauth_email.go
@@ -25,7 +25,7 @@ func newEmail() *schema.Resource {
 			},
 			"default_from_name": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The default From Name used when sending emails. If not provided, and a localized value cannot be determined, the default value for the tenant will be used. This is the display name part of the email address ( i.e. Jared Dunn <jared@piedpiper.com>).",
 			},
 			"default_html_template": {
@@ -47,7 +47,7 @@ func newEmail() *schema.Resource {
 			},
 			"from_email": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The email address that this email will be sent from. If not provided, the default value for the tenant will be used. This is the address part email address (i.e. Jared Dunn <jared@piedpiper.com>).",
 			},
 			"localized_from_names": {


### PR DESCRIPTION
Fix for #167

Per the API [documentation](https://fusionauth.io/docs/v1/tech/apis/emails#create-an-email-template), both `emailTemplate.defaultFromName` and `emailTemplate.fromEmail` are optional. 