### PR TITLE
Fix tenant.multiFactorConfiguration.loginPolicy handling

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -373,6 +373,7 @@ resource "fusionauth_tenant" "example" {
     - `seconds` - (Optional) The password minimum age in seconds. When enabled FusionAuth will not allow a password to be changed until it reaches this minimum age. Required when systemConfiguration.minimumPasswordAge.enabled is set to true.
     - `enabled` - (Optional) Indicates that the minimum password age is enabled and being enforced.
 * `multi_factor_configuration` - (Optional)
+    - `login_policy` - (Optional)  When set to `Enabled` and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to `Disabled`, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.
     - `authenticator` - (Optional)
         * `enabled` - (Optional) When enabled, users may utilize an authenticator application to complete a multi-factor authentication request. This method uses TOTP (Time-Based One-Time Password) as defined in RFC 6238 and often uses an native mobile app such as Google Authenticator.
     - `email` - (Optional)

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -367,6 +367,12 @@ func newTenant() *schema.Resource {
 				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"login_policy": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{fusionauth.MultiFactorLoginPolicy_Enabled.String(), fusionauth.MultiFactorLoginPolicy_Disabled.String()}, false),
+							Description:  "When set to Enabled and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to Disabled, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.",
+						},
 						"authenticator": {
 							Type:       schema.TypeList,
 							MaxItems:   1,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -189,6 +189,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			Seconds:    data.Get("minimum_password_age.0.seconds").(int),
 		},
 		MultiFactorConfiguration: fusionauth.TenantMultiFactorConfiguration{
+			LoginPolicy: fusionauth.MultiFactorLoginPolicy(data.Get("multi_factor_configuration.0.login_policy").(string)),
 			Authenticator: fusionauth.MultiFactorAuthenticatorMethod{
 				Enableable: buildEnableable("multi_factor_configuration.0.authenticator.0.enabled", data),
 			},
@@ -537,6 +538,7 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 
 	err = data.Set("multi_factor_configuration", []map[string]interface{}{
 		{
+			"login_policy": t.MultiFactorConfiguration.LoginPolicy,
 			"authenticator": []map[string]interface{}{{
 				"enabled": t.MultiFactorConfiguration.Authenticator.Enabled,
 			}},

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -209,6 +209,7 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "minimum_password_age.0.enabled", strconv.FormatBool(minimumPasswordAgeEnabled)),
 
 		// multi_factor_configuration
+		resource.TestCheckResourceAttr(tfResourcePath, "multi_factor_configuration.0.login_policy", "Enabled"),
 		resource.TestCheckResourceAttr(tfResourcePath, "multi_factor_configuration.0.authenticator.0.enabled", "true"),
 		// resource.TestCheckResourceAttr(tfResourcePath, "multi_factor_configuration.0.authenticator.0.template_id", "UUID"),
 		// requires paid edition of FusionAuth
@@ -567,6 +568,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
     enabled = %[7]t
   }
   multi_factor_configuration {
+    login_policy = "Enabled"
     authenticator {
       enabled     = true
       #template_id = "UUID"


### PR DESCRIPTION
Fixes #165

Note:
-  I didn't update the `github.com/FusionAuth/go-client` dependency since this would have involved more changes I considered beyond the scope of this MR. To this end, the `fusionauth.MultiFactorLoginPolicy_Required` isn't yet available and therefore you cannot set it to `Required` yet. Fixing that should be easy, though, after the dependency has been updated.