### PR TITLE
add a default value for login_policy

### DIFF
--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -370,6 +370,7 @@ func newTenant() *schema.Resource {
 						"login_policy": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Default:      "Enabled",
 							ValidateFunc: validation.StringInSlice([]string{fusionauth.MultiFactorLoginPolicy_Enabled.String(), fusionauth.MultiFactorLoginPolicy_Disabled.String()}, false),
 							Description:  "When set to Enabled and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to Disabled, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.",
 						},


### PR DESCRIPTION
Related Issue: #184 
Related PR: #185

`login_policy` is an optional field, but when not set the fusionauth client (or API) appears to return "Enabled" as the default value. Without defining a similar default in the provider we get a change notification when running `terraform plan`:

```
 # fusionauth_tenant.REDACTED_tenant will be updated in-place
  ~ resource "fusionauth_tenant" "REDACTED_tenant" {
        id                                 = "REDACTED"
      ~ multi_factor_configuration         = [
          ~ {
              ~ login_policy  = "Enabled" -> null
                # (3 unchanged elements hidden)
            },
        ]
        name                               = "REDACTED"
        # (6 unchanged attributes hidden)

        # (14 unchanged blocks hidden)
    }

```

This pull request sets the default value to "Enabled" which results in `terraform plan` correctly indicating that no changes will be applied.