### PR TITLE
Add `selfServiceUser` form type

### DIFF
--- a/docs/data-sources/form.md
+++ b/docs/data-sources/form.md
@@ -31,3 +31,4 @@ The following additional attributes are exported:
     * `registration` - This form will be used for self service registration.
     * `adminRegistration` - This form be used to customize the add and edit User Registration form in the FusionAuth UI.
     * `adminUser` - This form can be used to customize the add and edit User form in the FusionAuth UI.
+    * `selfServiceUser` - This form will be used to for self service user management.

--- a/fusionauth/datasource_fusionauth_form.go
+++ b/fusionauth/datasource_fusionauth_form.go
@@ -60,6 +60,7 @@ func dataSourceForm() *schema.Resource {
 					"registration",
 					"adminRegistration",
 					"adminUser",
+					"selfServiceUser",
 				}, false),
 			},
 		},

--- a/fusionauth/resource_fusionauth_form.go
+++ b/fusionauth/resource_fusionauth_form.go
@@ -60,6 +60,7 @@ func resourceForm() *schema.Resource {
 					"registration",
 					"adminRegistration",
 					"adminUser",
+					"selfServiceUser",
 				}, false),
 			},
 		},


### PR DESCRIPTION
Available since (presumably) 1.26. The API accepts the `selfServiceUser` input type. For comparison see typing of the fusionauth typescript client here: https://github.com/FusionAuth/fusionauth-typescript-client/blob/master/src/FusionAuthClient.ts#L7180-L7185