### PR TITLE
fix: Tenant JWT Configurations

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -355,8 +355,8 @@ resource "fusionauth_tenant" "example" {
 * `http_session_max_inactive_interval` - (Optional) Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
 * `issuer` - (Required) The named issuer used to sign tokens, this is generally your public fully qualified domain.
 * `jwt_configuration` - (Required)
-    - `access_token_key_id` - (Required) The unique id of the signing key used to sign the access token.
-    - `id_token_key_id` - (Required) The unique id of the signing key used to sign the Id token.
+    - `access_token_key_id` - (Optional) The unique id of the signing key used to sign the access token. Required prior to `1.30.0`.
+    - `id_token_key_id` - (Optional) The unique id of the signing key used to sign the Id token. Required prior to `1.30.0`.
     - `refresh_token_expiration_policy` - (Optional) The refresh token expiration policy.
     - `refresh_token_revocation_policy_on_login_prevented` - (Optional) When enabled, the refresh token will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
     - `refresh_token_revocation_policy_on_password_change` - (Optional) When enabled, the refresh token will be revoked when a user changes their password."

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -240,13 +240,13 @@ func newTenant() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"access_token_key_id": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.IsUUID,
 							Description:  "The unique id of the signing key used to sign the access token.",
 						},
 						"id_token_key_id": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.IsUUID,
 							Description:  "The unique id of the signing key used to sign the Id token.",
 						},

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -412,18 +412,6 @@ func testAccTenantResourceConfig(
 			themeKey,
 		)
 	}
-	if accessTokenKey != "" {
-		accessTokenKey = fmt.Sprintf(
-			"\n    access_token_key_id                   = fusionauth_key.test_%s.id\n",
-			accessTokenKey,
-		)
-	}
-	if idTokenKey != "" {
-		idTokenKey = fmt.Sprintf(
-			"\n    id_token_key_id                       = fusionauth_key.test_%s.id\n",
-			idTokenKey,
-		)
-	}
 	connectorPolicies := ""
 	if genericConnectorIncluded {
 		connectorPolicies = fmt.Sprintf(`
@@ -445,14 +433,14 @@ func testAccTenantResourceConfig(
 resource "fusionauth_tenant" "test_%[1]s" {
   #source_tenant_id = "UUID"
   #tenant_id        = "UUID"
-  # connector policies %[8]s
+  # connector policies %[6]s
   data = {
     user  = "data"
     lives = "here"
   }
   email_configuration {
     default_from_name  = "noreply"
-    default_from_email = "%[5]s"
+    default_from_email = "%[3]s"
     #forgot_password_email_template_id = ""
     host               = "smtp.example.com"
     password           = "s3cureP@ssw0rd"
@@ -551,7 +539,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
   }
   http_session_max_inactive_interval = 3400
   issuer   = "https://example.com"
-  jwt_configuration {%[3]s%[4]s
+  jwt_configuration {
     refresh_token_time_to_live_in_minutes = 43200
     time_to_live_in_seconds               = 3600
   }
@@ -564,8 +552,8 @@ resource "fusionauth_tenant" "test_%[1]s" {
     enabled = true
   }
   minimum_password_age {
-    seconds = %[6]d
-    enabled = %[7]t
+    seconds = %[4]d
+    enabled = %[5]t
   }
   multi_factor_configuration {
     login_policy = "Enabled"
@@ -628,8 +616,6 @@ resource "fusionauth_tenant" "test_%[1]s" {
 `,
 		resourceName,
 		themeKey,
-		accessTokenKey,
-		idTokenKey,
 		fromEmail,
 		minimumPasswordAgeSeconds,
 		minimumPasswordAgeEnabled,


### PR DESCRIPTION
Since FusionAuth 1.30.0 `access_token_key_id` & `id_token_key_id` are optional fields of `fusionauth_tenant.jwt_configuration[0]`.

[Source](https://fusionauth.io/docs/v1/tech/apis/tenants):
> tenant.jwtConfiguration.idTokenKeyId [UUID] OPTIONAL Defaults to key value of the FusionAuth application AVAILABLE SINCE 1.8.0
> The unique id of the signing key used to sign the Id token.
> 
> Prior to version 1.30.0 this value was required.

Fixes: [#203](https://github.com/gpsinsight/terraform-provider-fusionauth/issues/203)