### PR TITLE
feat: add Email Data Source

### DIFF
--- a/docs/data-sources/email.md
+++ b/docs/data-sources/email.md
@@ -1,0 +1,32 @@
+# Email Resource
+
+This data source is used to fetch information about a specific Email Template.
+
+[Emails API](https://fusionauth.io/docs/v1/tech/apis/emails)
+
+## Example Usage
+
+```hcl
+data "fusionauth_email" "default_breached_password" {
+    name = "[FusionAuth Default] Breached Password Notification"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Email Template.
+
+## Attributes Reference
+
+All the argument attributes are also exported as result attributes.
+
+* `id` - The Id of the Email Template.
+* `default_from_name` - The default From Name used when sending emails.
+* `default_html_template` - The default HTML Email Template.
+* `default_subject` - The default Subject used when sending emails.
+* `default_text_template` - The default Text Email Template.
+* `from_email` - The email address that this email will be sent from.
+* `localized_from_names` - The From Name used when sending emails to users who speak other languages.
+* `localized_html_templates` - The HTML Email Template used when sending emails to users who speak other languages.
+* `localized_subjects` - The Subject used when sending emails to users who speak other languages.
+* `localized_text_templates` - The Text Email Template used when sending emails to users who speak other languages.

--- a/fusionauth/datasource_fusionauth_email.go
+++ b/fusionauth/datasource_fusionauth_email.go
@@ -1,0 +1,132 @@
+package fusionauth
+
+import (
+	"context"
+
+	"github.com/FusionAuth/go-client/pkg/fusionauth"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceEmail() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEmailRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The name of the Email Template.",
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique Id of the Email Template",
+			},
+			"default_from_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The default From Name used when sending emails.",
+			},
+			"default_html_template": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The default HTML Email Template.",
+			},
+			"default_subject": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The default Subject used when sending emails.",
+			},
+			"default_text_template": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The default Text Email Template.",
+			},
+			"from_email": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The email address that this email will be sent from.",
+			},
+			"localized_from_names": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The From Name used when sending emails to users who speak other languages.",
+			},
+			"localized_html_templates": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The HTML Email Template used when sending emails to users who speak other languages.",
+			},
+			"localized_subjects": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The Subject used when sending emails to users who speak other languages.",
+			},
+			"localized_text_templates": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "The Text Email Template used when sending emails to users who speak other languages.",
+			},
+		},
+	}
+}
+
+func dataSourceEmailRead(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+	client := i.(Client)
+
+	resp, err := client.FAClient.RetrieveEmailTemplates()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := checkResponse(resp.StatusCode, nil); err != nil {
+		return diag.FromErr(err)
+	}
+	name := data.Get("name").(string)
+	var t *fusionauth.EmailTemplate
+
+	if len(resp.EmailTemplates) > 0 {
+		for i := range resp.EmailTemplates {
+			if resp.EmailTemplates[i].Name == name {
+				t = &resp.EmailTemplates[i]
+				break
+			}
+		}
+	}
+	if t == nil {
+		return diag.Errorf("couldn't find email template %s", name)
+	}
+	data.SetId(t.Id)
+	if err := data.Set("default_from_name", t.DefaultFromName); err != nil {
+		return diag.Errorf("email.default_from_name: %s", err.Error())
+	}
+	if err := data.Set("default_html_template", t.DefaultHtmlTemplate); err != nil {
+		return diag.Errorf("email.default_html_template: %s", err.Error())
+	}
+	if err := data.Set("default_subject", t.DefaultSubject); err != nil {
+		return diag.Errorf("email.default_subject: %s", err.Error())
+	}
+	if err := data.Set("default_text_template", t.DefaultTextTemplate); err != nil {
+		return diag.Errorf("email.default_text_template: %s", err.Error())
+	}
+	if err := data.Set("from_email", t.FromEmail); err != nil {
+		return diag.Errorf("email.from_email: %s", err.Error())
+	}
+	if err := data.Set("localized_from_names", t.LocalizedFromNames); err != nil {
+		return diag.Errorf("email.localized_from_names: %s", err.Error())
+	}
+	if err := data.Set("localized_html_templates", t.LocalizedHtmlTemplates); err != nil {
+		return diag.Errorf("email.localized_html_templates: %s", err.Error())
+	}
+	if err := data.Set("localized_subjects", t.LocalizedSubjects); err != nil {
+		return diag.Errorf("email.localized_subjects: %s", err.Error())
+	}
+	if err := data.Set("localized_text_templates", t.LocalizedTextTemplates); err != nil {
+		return diag.Errorf("email.localized_text_templates: %s", err.Error())
+	}
+	if err := data.Set("name", t.Name); err != nil {
+		return diag.Errorf("email.name: %s", err.Error())
+	}
+	return nil
+}

--- a/fusionauth/provider.go
+++ b/fusionauth/provider.go
@@ -60,6 +60,7 @@ func Provider() *schema.Provider {
 			"fusionauth_application":      dataSourceApplication(),
 			"fusionauth_application_role": dataSourceApplicationRole(),
 			"fusionauth_form":             dataSourceForm(),
+			"fusionauth_email":            dataSourceEmail(),
 			"fusionauth_idp":              dataSourceIDP(),
 			"fusionauth_lambda":           dataSourceLambda(),
 			"fusionauth_tenant":           dataSourceTenant(),


### PR DESCRIPTION
Adds the Email Template Data Source from an Email Template's name. Exposes exactly the same attributes as the [Email Resource](https://registry.terraform.io/providers/gpsinsight/fusionauth/latest/docs/resources/email).

Usage:

```hcl
data "fusionauth_email" "default_setup_password" {
  name = "[FusionAuth Default] Setup Password"
}

resource "fusionauth_tenant" "example" {
  name = "example"
  email_configuration {
    set_password_email_template_id = data.fusionauth_email.default_setup_password.id
    ...
```

plan output:

```
  # fusionauth_tenant.example will be updated in-place
  ~ resource "fusionauth_tenant" "example" {
        id                                 = "6081a8b0-b240-4c6b-bf97-f3ca1b545265"
        name                               = "example"
        # (7 unchanged attributes hidden)

      ~ email_configuration {
          + set_password_email_template_id = "2c8d6265-24ca-4d47-a60c-d8bb7abc7578"
```