### PR TITLE
feat(resource_fusionauth_tenant): adds support for all tenant rate limit configuration items.

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -239,6 +239,31 @@ resource "fusionauth_tenant" "example" {
       limit                  = 5
       time_period_in_seconds = 60
     }
+    forgot_password {
+      enabled                = false
+      limit                  = 5
+      time_period_in_seconds = 60
+    }
+    send_email_verification {
+      enabled                = false
+      limit                  = 5
+      time_period_in_seconds = 60
+    }
+    send_passwordless {
+      enabled                = false
+      limit                  = 5
+      time_period_in_seconds = 60
+    }
+    send_registration_verification {
+      enabled                = false
+      limit                  = 5
+      time_period_in_seconds = 60
+    }
+    send_two_factor {
+      enabled                = false
+      limit                  = 5
+      time_period_in_seconds = 60
+    }
   }
   theme_id = fusionauth_theme.example_theme.id
   user_delete_policy {
@@ -415,8 +440,28 @@ resource "fusionauth_tenant" "example" {
 * `rate_limit_configuration` - (Optional)
     - `failed_login` - (Optional)
       - `enabled` -  (Optional) Whether rate limiting is enabled for failed login.
-      - `limit` -  (Optional) The number of times a user can fail to login within the configured timePeriodInSeconds duration. If a Failed authentication action has been configured then it will take precedence.
-      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can fail login before being rate limited. 
+      - `limit` -  (Optional) The number of times a user can fail to login within the configured `time_period_in_seconds` duration. If a Failed authentication action has been configured then it will take precedence.
+      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can fail login before being rate limited.
+    - `forgot_password` - (Optional)
+      - `enabled` - (Optional) Whether rate limiting is enabled for forgot password.
+      - `limit` - (Optional) The number of times a user can request a forgot password email within the configured `time_period_in_seconds` duration.            
+      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can request a forgot password email before being rate limited.          
+    - `send_email_verification` - (Optional) 
+      - `enabled` - (Optional) Whether rate limiting is enabled for send email verification.
+      - `limit` - (Optional) The number of times a user can request a verification email within the configured `time_period_in_seconds` duration.                 
+      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can request a verification email before being rate limited. 
+    - `send_passwordless` - (Optional)
+      - `enabled` - (Optional) Whether rate limiting is enabled for send passwordless.
+      - `limit` - (Optional) The number of times a user can request a passwordless login email within the configured `time_period_in_seconds` duration.                
+      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can request a passwordless login email before being rate limited.
+    - `send_registration_verification` - (Optional)
+      - `enabled` - (Optional) Whether rate limiting is enabled for send registration verification.
+      - `limit` - (Optional) The number of times a user can request a registration verification email within the configured `time_period_in_seconds` duration.                 
+      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can request a registration verification email before being rate limited.
+    - `send_two_factor` - (Optional)
+      - `enabled` - (Optional) Whether rate limiting is enabled for send two factor.
+      - `limit` - (Optional) The number of times a user can request a two-factor code by email or SMS within the configured `time_period_in_seconds` duration.   
+      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can request a two-factor code by email or SMS before being rate limited.
 * `theme_id` - (Required) The unique Id of the theme to be used to style the login page and other end user templates.
 * `username_configuration` - (Optional)
     - `unique` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -544,6 +544,156 @@ func newTenant() *schema.Resource {
 								},
 							},
 						},
+						"forgot_password": {
+							Optional: true,
+							Computed: true,
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Whether rate limiting is enabled for forgot password.",
+									},
+									"limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      5,
+										Description:  "The number of times a user can request a forgot password email within the configured `time_period_in_seconds` duration. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"time_period_in_seconds": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      60,
+										Description:  "The duration for the number of times a user can request a forgot password email before being rate limited. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+								},
+							},
+						},
+						"send_email_verification": {
+							Optional: true,
+							Computed: true,
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Whether rate limiting is enabled for send email verification.",
+									},
+									"limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      5,
+										Description:  "The number of times a user can request a verification email within the configured `time_period_in_seconds` duration. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"time_period_in_seconds": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      60,
+										Description:  "The duration for the number of times a user can request a verification email before being rate limited. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+								},
+							},
+						},
+						"send_passwordless": {
+							Optional: true,
+							Computed: true,
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Whether rate limiting is enabled for send passwordless.",
+									},
+									"limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      5,
+										Description:  "The number of times a user can request a passwordless login email within the configured `time_period_in_seconds` duration. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"time_period_in_seconds": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      60,
+										Description:  "The duration for the number of times a user can request a passwordless login email before being rate limited. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+								},
+							},
+						},
+						"send_registration_verification": {
+							Optional: true,
+							Computed: true,
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Whether rate limiting is enabled for send registration verification.",
+									},
+									"limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      5,
+										Description:  "The number of times a user can request a registration verification email within the configured `time_period_in_seconds` duration. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"time_period_in_seconds": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      60,
+										Description:  "The duration for the number of times a user can request a registration verification email before being rate limited. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+								},
+							},
+						},
+						"send_two_factor": {
+							Optional: true,
+							Computed: true,
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Whether rate limiting is enabled for send two factor.",
+									},
+									"limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      5,
+										Description:  "The number of times a user can request a two-factor code by email or SMS within the configured `time_period_in_seconds` duration. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"time_period_in_seconds": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      60,
+										Description:  "The duration for the number of times a user can request a two-factor code by email or SMS before being rate limited. Value must be greater than 0.",
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -244,6 +244,31 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 				Limit:               data.Get("rate_limit_configuration.0.failed_login.0.limit").(int),
 				TimePeriodInSeconds: data.Get("rate_limit_configuration.0.failed_login.0.time_period_in_seconds").(int),
 			},
+			ForgotPassword: fusionauth.RateLimitedRequestConfiguration{
+				Enableable:          buildEnableable("rate_limit_configuration.0.forgot_password.0.enabled", data),
+				Limit:               data.Get("rate_limit_configuration.0.forgot_password.0.limit").(int),
+				TimePeriodInSeconds: data.Get("rate_limit_configuration.0.forgot_password.0.time_period_in_seconds").(int),
+			},
+			SendEmailVerification: fusionauth.RateLimitedRequestConfiguration{
+				Enableable:          buildEnableable("rate_limit_configuration.0.send_email_verification.0.enabled", data),
+				Limit:               data.Get("rate_limit_configuration.0.send_email_verification.0.limit").(int),
+				TimePeriodInSeconds: data.Get("rate_limit_configuration.0.send_email_verification.0.time_period_in_seconds").(int),
+			},
+			SendPasswordless: fusionauth.RateLimitedRequestConfiguration{
+				Enableable:          buildEnableable("rate_limit_configuration.0.send_passwordless.0.enabled", data),
+				Limit:               data.Get("rate_limit_configuration.0.send_passwordless.0.limit").(int),
+				TimePeriodInSeconds: data.Get("rate_limit_configuration.0.send_passwordless.0.time_period_in_seconds").(int),
+			},
+			SendRegistrationVerification: fusionauth.RateLimitedRequestConfiguration{
+				Enableable:          buildEnableable("rate_limit_configuration.0.send_registration_verification.0.enabled", data),
+				Limit:               data.Get("rate_limit_configuration.0.send_registration_verification.0.limit").(int),
+				TimePeriodInSeconds: data.Get("rate_limit_configuration.0.send_registration_verification.0.time_period_in_seconds").(int),
+			},
+			SendTwoFactor: fusionauth.RateLimitedRequestConfiguration{
+				Enableable:          buildEnableable("rate_limit_configuration.0.send_two_factor.0.enabled", data),
+				Limit:               data.Get("rate_limit_configuration.0.send_two_factor.0.limit").(int),
+				TimePeriodInSeconds: data.Get("rate_limit_configuration.0.send_two_factor.0.time_period_in_seconds").(int),
+			},
 		},
 		ThemeId: data.Get("theme_id").(string),
 		UserDeletePolicy: fusionauth.TenantUserDeletePolicy{
@@ -612,6 +637,44 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 	})
 	if err != nil {
 		return diag.Errorf("tenant.password_validation_rules: %s", err.Error())
+	}
+
+	err = data.Set("rate_limit_configuration", []map[string]interface{}{
+		{
+			"failed_login": []map[string]interface{}{{
+				"enabled":                t.RateLimitConfiguration.FailedLogin.Enabled,
+				"limit":                  t.RateLimitConfiguration.FailedLogin.Limit,
+				"time_period_in_seconds": t.RateLimitConfiguration.FailedLogin.TimePeriodInSeconds,
+			}},
+			"forgot_password": []map[string]interface{}{{
+				"enabled":                t.RateLimitConfiguration.ForgotPassword.Enabled,
+				"limit":                  t.RateLimitConfiguration.ForgotPassword.Limit,
+				"time_period_in_seconds": t.RateLimitConfiguration.ForgotPassword.TimePeriodInSeconds,
+			}},
+			"send_email_verification": []map[string]interface{}{{
+				"enabled":                t.RateLimitConfiguration.SendEmailVerification.Enabled,
+				"limit":                  t.RateLimitConfiguration.SendEmailVerification.Limit,
+				"time_period_in_seconds": t.RateLimitConfiguration.SendEmailVerification.TimePeriodInSeconds,
+			}},
+			"send_passwordless": []map[string]interface{}{{
+				"enabled":                t.RateLimitConfiguration.SendPasswordless.Enabled,
+				"limit":                  t.RateLimitConfiguration.SendPasswordless.Limit,
+				"time_period_in_seconds": t.RateLimitConfiguration.SendPasswordless.TimePeriodInSeconds,
+			}},
+			"send_registration_verification": []map[string]interface{}{{
+				"enabled":                t.RateLimitConfiguration.SendRegistrationVerification.Enabled,
+				"limit":                  t.RateLimitConfiguration.SendRegistrationVerification.Limit,
+				"time_period_in_seconds": t.RateLimitConfiguration.SendRegistrationVerification.TimePeriodInSeconds,
+			}},
+			"send_two_factor": []map[string]interface{}{{
+				"enabled":                t.RateLimitConfiguration.SendTwoFactor.Enabled,
+				"limit":                  t.RateLimitConfiguration.SendTwoFactor.Limit,
+				"time_period_in_seconds": t.RateLimitConfiguration.SendTwoFactor.TimePeriodInSeconds,
+			}},
+		},
+	})
+	if err != nil {
+		return diag.Errorf("tenant.rate_limit_configuration: %s", err.Error())
 	}
 
 	if err := data.Set("theme_id", t.ThemeId); err != nil {

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -242,10 +242,25 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "password_validation_rules.0.validate_on_login", "true"),
 
 		// rate_limit_configuration
-		resource.TestCheckResourceAttrSet(tfResourcePath, "rate_limit_configuration"),
+		resource.TestCheckResourceAttrSet(tfResourcePath, "rate_limit_configuration.#"),
 		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.enabled", "true"),
-		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.limit", "5"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.limit", "6"),
 		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.time_period_in_seconds", "60"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.forgot_password.0.enabled", "false"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.forgot_password.0.limit", "5"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.forgot_password.0.time_period_in_seconds", "59"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_email_verification.0.enabled", "true"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_email_verification.0.limit", "4"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_email_verification.0.time_period_in_seconds", "58"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_passwordless.0.enabled", "false"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_passwordless.0.limit", "3"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_passwordless.0.time_period_in_seconds", "57"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_registration_verification.0.enabled", "true"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_registration_verification.0.limit", "2"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_registration_verification.0.time_period_in_seconds", "56"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_two_factor.0.enabled", "false"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_two_factor.0.limit", "1"),
+		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.send_two_factor.0.time_period_in_seconds", "55"),
 
 		resource.TestCheckResourceAttrSet(tfResourcePath, "theme_id"),
 
@@ -602,9 +617,34 @@ resource "fusionauth_tenant" "test_%[1]s" {
   }
   rate_limit_configuration {
     failed_login {
-        enabled                = true
-        limit                  = 5
-        time_period_in_seconds = 60
+      enabled                = true
+      limit                  = 6
+      time_period_in_seconds = 60
+    }
+    forgot_password {
+      enabled                = false
+      limit                  = 5
+      time_period_in_seconds = 59
+    }
+    send_email_verification {
+      enabled                = true
+      limit                  = 4
+      time_period_in_seconds = 58
+    }
+    send_passwordless {
+      enabled                = false
+      limit                  = 3
+      time_period_in_seconds = 57
+    }
+    send_registration_verification {
+      enabled                = true
+      limit                  = 2
+      time_period_in_seconds = 56
+    }
+    send_two_factor {
+      enabled                = false
+      limit                  = 1
+      time_period_in_seconds = 55
     }
   }
   # theme_id%[2]s


### PR DESCRIPTION
Builds upon the changes introduced through #212. 🎉 

Also fixes an issue where the server response for rate limits weren't deserialised into terraform state.
This could lead to issues if a rouge operator happened to change a setting server-side and terraform wouldn't reconcile the differences.