### PR TITLE
fix: update to support tenant captcha configuration

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -257,182 +257,182 @@ resource "fusionauth_tenant" "example" {
 
 ## Argument Reference
 
-- `source_tenant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
-- `tenant_id` - (Optional) The Id to use for the new Tenant. If not specified a secure random UUID will be generated.
-- `access_control_configuration` - (Optiona)
-  - `ui_ip_access_control_list_id` - (Optional) The Id of the IP Access Control List limiting access to all applications in this tenant.
-- `captcha_configuration` - (Optiona)
-  - `enabled` - (Optional) Whether captcha configuration is enabled.
-  - `captcha_method` - (Optional) The type of captcha method to use. This field is required when tenant.captchaConfiguration.enabled is set to true.
-  - `secret_key` - (Optional) The secret key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
-  - `site_key` - (Optional) The site key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
-  - `threshold` - (Optional) The numeric threshold which separates a passing score from a failing one. This value only applies if using either the Google v3 or HCaptcha Enterprise method, otherwise this value is ignored.
-- `connector_policy` - (Optional) A list of Connector policies. Users will be authenticated against Connectors in order. Each Connector can be included in this list at most once and must exist.
-  - `connector_id` - (Optional) The identifier of the Connector to which this policy refers.
-  - `domains` - (Optional) A list of email domains to which this connector should apply. A value of ["*"] indicates this connector applies to all users.
-  - `migrate` - (Optional) If true, the user’s data will be migrated to FusionAuth at first successful authentication; subsequent authentications will occur against the FusionAuth datastore. If false, the Connector’s source will be treated as authoritative.
-- `data` - (Optional) An object that can hold any information about the Tenant that should be persisted.
-- `email_configuration` - (Required)
-  - `additional_headers` - (Optional) The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
-  - `email_update_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
-  - `email_verified_email_template_id` - (Optional) The Id of the Email Template used to verify user emails.
-  - `host` - (Required) The host name of the SMTP server that FusionAuth will use.
-  - `implicit_email_verification_allowed` - (Optional) When set to true, this allows email to be verified as a result of completing a similar email based workflow such as change password. When seto false, the user must explicitly complete the email verification workflow even if the user has already completed a similar email workflow such as change password.
-  - `login_id_in_use_on_create_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
-  - `login_id_in_use_on_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
-  - `login_new_device_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they log in on a new device.
-  - `login_suspicious_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a suspicious login occurs.
-  - `password_reset_success_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password habeen reset.
-  - `password_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password has been rese
-  - `default_from_name` - (Optional) The default From Name used in sending emails when a from name is not provided on an individual email template. This is the display name part of the email address ( i.e. Jared Dunn <jared@piedpiper.com>).
-  - `default_from_email` - (Optional) The default email address that emails will be sent from when a from address is not provided on an individual email template. This is the address part email address (i.e. Jared Dunn <jared@piedpiper.com>).
-  - `forgot_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
-  - `password` - (Optional) An optional password FusionAuth will use to authenticate with the SMTP server.
-  - `passwordless_email_template_id` - (Optional) The Id of the Passwordless Email Template.
-  - `port` - (Required) The port of the SMTP server that FusionAuth will use.
-  - `properties` - (Optional) Additional Email Configuration in a properties file formatted String.
-  - `security` - (Optional) The type of security protocol FusionAuth will use when connecting to the SMTP server.
-  - `set_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user had their account created for them and they must set their password manually and they are sent an email to set their password.
-  - `username` - (Optional) An optional username FusionAuth will to authenticate with the SMTP server.
-  - `verification_email_template_id` - (Optional) The Id of the Email Template that is used to send the verification emails to users. These emails are used to verify that a user’s email address ivalid. If either the verifyEmail or verifyEmailWhenChanged fields are true this field is required.
-  - `verification_strategy` - (Optional) The process by which the user will verify their email address. Possible values are `ClickableLink` or `FormField`.
-  - `verify_email` - (Optional) Whether the user’s email addresses are verified when the registers with your application.
-  - `verify_email_when_changed` - (Optional) Whether the user’s email addresses are verified when the user changes them.
-  - `two_factor_method_add_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been added to their account.
-  - `two_factor_method_remove_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been removed from their account.
-  - `unverified` - (Optional)
-    - `allow_email_change_when_gated` - (Optional) When this value is set to true, the user is allowed to change their email address when they are gated because they haven’t verified their email address.
-    - `behavior` = (Optional) The behavior when detecting breaches at time of user login
-- `event_configuration` - (Optional)
-  - `event` - (Optional) The event type
-  - `enabled` - (Optional) Whether or not FusionAuth should send these types of events to any configured Webhooks.
-  - `transaction_type` - (Optional) The transaction type that FusionAuth uses when sending these types of events to any configured Webhooks.
-- `external_identifier_configuration` - (Required)
-  - `authorization_grant_id_time_to_live_in_seconds` - (Required) The time in seconds until a OAuth authorization code in no longer valid to be exchanged for an access token. This is essentially the time allowed between the start of an Authorization request during the Authorization code grant and when you request an access token using this authorization code on the Token endpoint.
-  - `change_password_id_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the change password Id.
-    - `type` - (Required) The type of the secure generator used for generating the change password Id.
-  - `change_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
-  - `device_code_time_to_live_in_seconds` - (Required) The time in seconds until a device code Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
-  - `device_user_code_id_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the change password Id.
-    - `type` - (Required) The type of the secure generator used for generating the change password Id.
-  - `email_verification_id_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the change password Id.
-    - `type` - (Required) The type of the secure generator used for generating the change password Id.
-  - `email_verification_one_time_code_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the email verification one time code.
-    - `type` - (Optional) The type of the secure generator used for generating the email verification one time code.
-  - `email_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a email verification Id is no longer valid and cannot be used by the Verify Email API. Value must be greater than 0.
-  - `external_authentication_id_time_to_live_in_seconds` - (Required) The time in seconds until an external authentication Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
-  - `one_time_password_time_to_live_in_seconds` - (Required) The time in seconds until a One Time Password is no longer valid and cannot be used by the Login API. Value must be greater than 0.
-  - `passwordless_login_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the change password Id.
-    - `type` - (Required) The type of the secure generator used for generating the change password Id.
-  - `passwordless_login_time_to_live_in_seconds` - (Required) The time in seconds until a passwordless code is no longer valid and cannot be used by the Passwordless API. Value must be greater than 0.
-  - `registration_verification_id_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the change password Id.
-    - `type` - (Required) The type of the secure generator used for generating the change password Id.
-  - `registration_verification_one_time_code_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the registration verification one time code.
-    - `type` - (Optional) The type of the secure generator used for generating the registration verification one time code.
-  - `registration_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
-  - `saml_v2_authn_request_id_ttl_seconds` - (Optional) The time in seconds that a SAML AuthN request will be eligible for use to authenticate with FusionAuth.
-  - `setup_password_id_generator` - (Required)
-    - `length` - (Required) The length of the secure generator used for generating the change password Id.
-    - `type` - (Required) The type of the secure generator used for generating the change password Id.
-  - `setup_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a setup password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
-  - `two_factor_id_time_to_live_in_seconds` - (Required) The time in seconds until a two factor Id is no longer valid and cannot be used by the Two Factor Login API. Value must be greater than 0.
-  - `trust_token_time_to_live_in_seconds` - (Optional) The number of seconds before the Trust Token is no longer valid to complete a request that requires trust. Value must be greater than 0.
-  - `pending_account_link_time_to_live_in_seconds` - (Optional) The number of seconds before the pending account link identifier is no longer valid to complete an account link request. Value must be greater than 0.
-  - `two_factor_trust_id_time_to_live_in_seconds` - (Require) The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication during the next authentication attempt. Value must be greater than 0.
-  - `two_factor_one_time_code_id_generator` - (Required)
-    - `length` - (Required) TThe length of the secure generator used for generating the the two factor code Id.
-    - `type` - (Optional) The type of the secure generator used for generating the two factor one time code Id.
-- `failed_authentication_configuration` - (Optional)
-  - `action_duration` - (Required) The duration of the User Action. This value along with the actionDurationUnit will be used to set the duration of the User Action. Value must be greater than 0.
-  - `action_duration_unit` - (Optional) The unit of time associated with a duration.
-  - `reset_count_in_seconds` - (Optional) The length of time in seconds before the failed authentication count will be reset. Value must be greater than 0.
-  - `too_many_attempts` - (Optional) The number of failed attempts considered to be too many. Once this threshold is reached the specified User Action will be applied to the user for the duration specified. Value must be greater than 0.
-  - `user_action_id` - (Optional) The Id of the User Action that is applied when the threshold is reached for too many failed authentication attempts.
-- `family_configuration` - (Optional)
-  - `allow_child_registrations` - (Optional) Whether to allow child registrations.
-  - `confirm_child_email_template_id` - (Optional) The unique Id of the email template to use when confirming a child.
-  - `delete_orphaned_accounts` - (Optional) Indicates that child users without parental verification will be permanently deleted after tenant.familyConfiguration.deleteOrphanedAccountsDays days.
-  - `delete_orphaned_accounts_days` - (Optional) The number of days from creation child users will be retained before being deleted for not completing parental verification. Value must be greater than 0.
-  - `enabled` - (Optional) Whether family configuration is enabled.
-  - `family_request_email_template_id` - (Optional) The unique Id of the email template to use when a family request is made.
-  - `maximum_child_age` - (Optional) The maximum age of a child. Value must be greater than 0.
-  - `minimum_owner_age` - (Optional) The minimum age to be an owner. Value must be greater than 0.
-  - `parent_email_required` - (Optional) Whether a parent email is required.
-  - `parent_registration_email_template_id` - (Optional) The unique Id of the email template to use for parent registration.
-- `form_configuration` - (Optional)
-  - `admin_user_form_id` - (Optional) The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI.
-- `http_session_max_inactive_interval` - (Optional) Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
-- `issuer` - (Required) The named issuer used to sign tokens, this is generally your public fully qualified domain.
-- `jwt_configuration` - (Required)
-  - `access_token_key_id` - (Optional) The unique id of the signing key used to sign the access token. Required prior to `1.30.0`.
-  - `id_token_key_id` - (Optional) The unique id of the signing key used to sign the Id token. Required prior to `1.30.0`.
-  - `refresh_token_expiration_policy` - (Optional) The refresh token expiration policy.
-  - `refresh_token_revocation_policy_on_login_prevented` - (Optional) When enabled, the refresh token will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
-  - `refresh_token_revocation_policy_on_password_change` - (Optional) When enabled, the refresh token will be revoked when a user changes their password."
-  - `refresh_token_time_to_live_in_minutes` - (Required) The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
-  - `refresh_token_usage_policy` - (Optional) The refresh token usage policy.
-  - `time_to_live_in_seconds` - (Required) The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.
-- `login_configuration`
-  - `require_authentication` - (Optional) Indicates whether to require an API key for the Login API when an `applicationId` is not provided. When an `applicationId` is provided to the Login API call, the application configuration will take precedence. In almost all cases, you will want to this to be `true`.
-- `logout_url` - (Optional) The logout redirect URL when sending the user’s browser to the /oauth2/logout URI of the FusionAuth Front End. This value is only used when a logout URL is not defined in your Application.
-- `maximum_password_age` - (Optional)
-  - `days` - (Optional) The password maximum age in days. The number of days after which FusionAuth will require a user to change their password. Required when systemConfiguration.maximumPasswordAge.enabled is set to true.
-  - `enabled` - (Optional) Indicates that the maximum password age is enabled and being enforced.
-- `minimum_password_age` - (Optional)
-  - `seconds` - (Optional) The password minimum age in seconds. When enabled FusionAuth will not allow a password to be changed until it reaches this minimum age. Required when systemConfiguration.minimumPasswordAge.enabled is set to true.
-  - `enabled` - (Optional) Indicates that the minimum password age is enabled and being enforced.
-- `multi_factor_configuration` - (Optional)
-  - `login_policy` - (Optional) When set to `Enabled` and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to `Disabled`, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.
-  - `authenticator` - (Optional)
-    - `enabled` - (Optional) When enabled, users may utilize an authenticator application to complete a multi-factor authentication request. This method uses TOTP (Time-Based One-Time Password) as defined in RFC 6238 and often uses an native mobile app such as Google Authenticator.
-  - `email` - (Optional)
-    - `enabled` - (Optional) When enabled, users may utilize an email address to complete a multi-factor authentication request.
-    - `template_id` - (Optional) The Id of the email template that is used when notifying a user to complete a multi-factor authentication request.
-  - `sms` - (Optional)
-    - `enabled` - (Optional) When enabled, users may utilize a mobile phone number to complete a multi-factor authentication request.
-    - `messenger_id` - (Optional) The messenger that is used to deliver a SMS multi-factor authentication request.
-    - `template_id` - (Optional) The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
-- `name` - (Required) The unique name of the Tenant.
-- `oauth_configuration` - (Optional)
-  - `client_credentials_access_token_populate_lambda_id` - (Optional) The Id of a lambda that will be called to populate the JWT during a client credentials grant. **Note:** A paid edition of FusionAuth is required to utilize client credentials grant.
-- `password_encryption_configuration` - (Optional)
-  - `encryption_scheme` - (Optional) The default method for encrypting the User’s password.
-  - `encryption_scheme_factor` - (Optional) The factor used by the password encryption scheme. If not provided, the PasswordEncryptor provides a default value. Generally this will be used as an iteration count to generate the hash. The actual use of this value is up to the PasswordEncryptor implementation.
-  - `modify_encryption_scheme_on_login` - (Optional) When enabled a user’s hash configuration will be modified to match these configured settings. This can be useful to increase a password hash strength over time or upgrade imported users to a more secure encryption scheme after an initial import.
-- `password_validation_rules` - (Optional)
-  - `breach_detection` - (Optional)
-    - `enabled` - (Optional) Whether to enable Reactor breach detection. Requires an activated license.
-    - `match_mode` - (Optional) The level of severity where Reactor will consider a breach.
-    - `notify_user_email_template_id` - (Optional) The Id of the email template to use when notifying user of breached password. Required if tenant.passwordValidationRules.breachDetection.onLogin is set to NotifyUser.
-    - `on_login` - (Optional) The behavior when detecting breaches at time of user login
-  - `max_length` - (Optional) The maximum length of a password when a new user is created or a user requests a password change.
-  - `min_length` - (Optional) The minimum length of a password when a new user is created or a user requests a password change.
-  - `remember_previous_passwords` - (Optional)
-    - `count` - (Optional) The number of previous passwords to remember. Value must be greater than 0.
-    - `enabled` - (Optional) Whether to prevent a user from using any of their previous passwords.
-  - `required_mixed_case` - (Optional) Whether to force the user to use at least one uppercase and one lowercase character.
-  - `require_non_alpha` - (Optional) Whether to force the user to use at least one non-alphanumeric character.
-  - `require_number` - (Optional) Whether to force the user to use at least one number.
-  - `validate_on_login` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
-- `rate_limit_configuration` - (Optional)
-  - `failed_login` - (Optional)
-    - `enabled` - (Optional) Whether rate limiting is enabled for failed login.
-    - `limit` - (Optional) The number of times a user can fail to login within the configured timePeriodInSeconds duration. If a Failed authentication action has been configured then it will take precedence.
-    - `time_period_in_seconds` - (Optional) The duration for the number of times a user can fail login before being rate limited.
-- `theme_id` - (Required) The unique Id of the theme to be used to style the login page and other end user templates.
-- `username_configuration` - (Optional)
-  - `unique` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
-    - `enabled` - (Optional) When true, FusionAuth will handle username collisions by generating a random suffix.
-    - `number_of_digits` - (Optional) The maximum number of digits to use when building a unique suffix for a username. A number will be randomly selected and will be 1 or more digits up to this configured value in length. For example, if this value is 5, the suffix will be a number between 00001 and 99999, inclusive.
-    - `separator` - (Optional) A single character to use as a separator from the requested username and a unique suffix that is added when a duplicate username is detected. This value can be a single non-alphanumeric ASCII character.
-    - `strategy` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
-- `user_delete_policy` - (Optional)
-  - `unverified_enabled` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
-  - `unverified_number_of_days_to_retain` - (Optional)
+* `source_tenant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
+* `tenant_id` - (Optional) The Id to use for the new Tenant. If not specified a secure random UUID will be generated.
+* `access_control_configuration` - (Optiona)
+    - `ui_ip_access_control_list_id` - (Optional) The Id of the IP Access Control List limiting access to all applications in this tenant.
+* `captcha_configuration` - (Optional)
+    - `enabled` - (Optional) Whether captcha configuration is enabled.
+    - `captcha_method` - (Optional) The type of captcha method to use. This field is required when tenant.captchaConfiguration.enabled is set to true.
+    - `secret_key` - (Optional) The secret key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
+    - `site_key` - (Optional) The site key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
+    - `threshold` - (Optional) The numeric threshold which separates a passing score from a failing one. This value only applies if using either the Google v3 or HCaptcha Enterprise method, otherwise this value is ignored.
+* `connector_policy` - (Optional) A list of Connector policies. Users will be authenticated against Connectors in order. Each Connector can be included in this list at most once and must exist.
+    - `connector_id` - (Optional) The identifier of the Connector to which this policy refers.
+    - `domains` - (Optional) A list of email domains to which this connector should apply. A value of ["*"] indicates this connector applies to all users.
+    - `migrate` - (Optional) If true, the user’s data will be migrated to FusionAuth at first successful authentication; subsequent authentications will occur against the FusionAuth datastore. If false, the Connector’s source will be treated as authoritative.
+* `data` - (Optional) An object that can hold any information about the Tenant that should be persisted.
+* `email_configuration` - (Required)
+    - `additional_headers` - (Optional) The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
+    - `email_update_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
+    - `email_verified_email_template_id` - (Optional) The Id of the Email Template used to verify user emails.
+    - `host` - (Required) The host name of the SMTP server that FusionAuth will use.
+    - `implicit_email_verification_allowed` - (Optional) When set to true, this allows email to be verified as a result of completing a similar email based workflow such as change password. When seto false, the user must explicitly complete the email verification workflow even if the user has already completed a similar email workflow such as change password.
+    - `login_id_in_use_on_create_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
+    - `login_id_in_use_on_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
+    - `login_new_device_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they log in on a new device.
+    - `login_suspicious_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a suspicious login occurs.
+    - `password_reset_success_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password habeen reset.
+    - `password_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password has been rese
+    - `default_from_name` - (Optional) The default From Name used in sending emails when a from name is not provided on an individual email template. This is the display name part of the email address ( i.e. Jared Dunn <jared@piedpiper.com>).
+    - `default_from_email` - (Optional) The default email address that emails will be sent from when a from address is not provided on an individual email template. This is the address part email address (i.e. Jared Dunn <jared@piedpiper.com>).
+    - `forgot_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
+    - `password` - (Optional) An optional password FusionAuth will use to authenticate with the SMTP server.
+    - `passwordless_email_template_id` - (Optional) The Id of the Passwordless Email Template.
+    - `port` - (Required) The port of the SMTP server that FusionAuth will use.
+    - `properties` - (Optional) Additional Email Configuration in a properties file formatted String.
+    - `security` - (Optional) The type of security protocol FusionAuth will use when connecting to the SMTP server.
+    - `set_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user had their account created for them and they must set their password manually and they are sent an email to set their password.
+    - `username` - (Optional) An optional username FusionAuth will to authenticate with the SMTP server.
+    - `verification_email_template_id` - (Optional) The Id of the Email Template that is used to send the verification emails to users. These emails are used to verify that a user’s email address ivalid. If either the verifyEmail or verifyEmailWhenChanged fields are true this field is required.
+    - `verification_strategy` - (Optional) The process by which the user will verify their email address. Possible values are `ClickableLink` or `FormField`.
+    - `verify_email` - (Optional) Whether the user’s email addresses are verified when the registers with your application.
+    - `verify_email_when_changed` - (Optional) Whether the user’s email addresses are verified when the user changes them.
+    - `two_factor_method_add_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been added to their account.
+    - `two_factor_method_remove_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been removed from their account.
+    - `unverified` - (Optional)
+        - `allow_email_change_when_gated` - (Optional) When this value is set to true, the user is allowed to change their email address when they are gated because they haven’t verified their email address.
+        - `behavior` = (Optional) The behavior when detecting breaches at time of user login
+* `event_configuration` - (Optional)
+    - `event` - (Optional) The event type
+    - `enabled` - (Optional) Whether or not FusionAuth should send these types of events to any configured Webhooks.
+    - `transaction_type` - (Optional) The transaction type that FusionAuth uses when sending these types of events to any configured Webhooks.
+* `external_identifier_configuration` - (Required)
+    - `authorization_grant_id_time_to_live_in_seconds` - (Required) The time in seconds until a OAuth authorization code in no longer valid to be exchanged for an access token. This is essentially the time allowed between the start of an Authorization request during the Authorization code grant and when you request an access token using this authorization code on the Token endpoint.
+    - `change_password_id_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the change password Id.
+        - `type` - (Required) The type of the secure generator used for generating the change password Id.
+    - `change_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
+    - `device_code_time_to_live_in_seconds` - (Required) The time in seconds until a device code Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
+    - `device_user_code_id_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the change password Id.
+        - `type` - (Required) The type of the secure generator used for generating the change password Id.
+    - `email_verification_id_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the change password Id.
+        - `type` - (Required) The type of the secure generator used for generating the change password Id.
+    - `email_verification_one_time_code_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the email verification one time code.
+        - `type` - (Optional) The type of the secure generator used for generating the email verification one time code.
+    - `email_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a email verification Id is no longer valid and cannot be used by the Verify Email API. Value must be greater than 0.
+    - `external_authentication_id_time_to_live_in_seconds` - (Required) The time in seconds until an external authentication Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
+    - `one_time_password_time_to_live_in_seconds` - (Required) The time in seconds until a One Time Password is no longer valid and cannot be used by the Login API. Value must be greater than 0.
+    - `passwordless_login_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the change password Id.
+        - `type` - (Required) The type of the secure generator used for generating the change password Id.
+    - `passwordless_login_time_to_live_in_seconds` - (Required) The time in seconds until a passwordless code is no longer valid and cannot be used by the Passwordless API. Value must be greater than 0.
+    - `registration_verification_id_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the change password Id.
+        - `type` - (Required) The type of the secure generator used for generating the change password Id.
+    - `registration_verification_one_time_code_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the registration verification one time code.
+        - `type` - (Optional) The type of the secure generator used for generating the registration verification one time code.
+    - `registration_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
+    - `saml_v2_authn_request_id_ttl_seconds` - (Optional) The time in seconds that a SAML AuthN request will be eligible for use to authenticate with FusionAuth.
+    - `setup_password_id_generator` - (Required)
+        - `length` - (Required) The length of the secure generator used for generating the change password Id.
+        - `type` - (Required) The type of the secure generator used for generating the change password Id.
+    - `setup_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a setup password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
+    - `two_factor_id_time_to_live_in_seconds` - (Required) The time in seconds until a two factor Id is no longer valid and cannot be used by the Two Factor Login API. Value must be greater than 0.
+    - `trust_token_time_to_live_in_seconds` - (Optional) The number of seconds before the Trust Token is no longer valid to complete a request that requires trust. Value must be greater than 0.
+    - `pending_account_link_time_to_live_in_seconds` - (Optional) The number of seconds before the pending account link identifier is no longer valid to complete an account link request. Value must be greater than 0.
+    - `two_factor_trust_id_time_to_live_in_seconds` - (Require) The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication during the next authentication attempt. Value must be greater than 0.
+    - `two_factor_one_time_code_id_generator` - (Required)
+        - `length` - (Required) TThe length of the secure generator used for generating the the two factor code Id.
+        - `type` - (Optional) The type of the secure generator used for generating the two factor one time code Id.
+* `failed_authentication_configuration` - (Optional)
+    - `action_duration` - (Required) The duration of the User Action. This value along with the actionDurationUnit will be used to set the duration of the User Action. Value must be greater than 0.
+    - `action_duration_unit` - (Optional) The unit of time associated with a duration.
+    - `reset_count_in_seconds` - (Optional) The length of time in seconds before the failed authentication count will be reset. Value must be greater than 0.
+    - `too_many_attempts` - (Optional) The number of failed attempts considered to be too many. Once this threshold is reached the specified User Action will be applied to the user for the duration specified. Value must be greater than 0.
+    - `user_action_id` - (Optional) The Id of the User Action that is applied when the threshold is reached for too many failed authentication attempts.
+* `family_configuration` - (Optional)
+    - `allow_child_registrations` - (Optional) Whether to allow child registrations.
+    - `confirm_child_email_template_id` - (Optional) The unique Id of the email template to use when confirming a child.
+    - `delete_orphaned_accounts` - (Optional) Indicates that child users without parental verification will be permanently deleted after tenant.familyConfiguration.deleteOrphanedAccountsDays days.
+    - `delete_orphaned_accounts_days` - (Optional) The number of days from creation child users will be retained before being deleted for not completing parental verification. Value must be greater than 0.
+    - `enabled` - (Optional) Whether family configuration is enabled.
+    - `family_request_email_template_id` - (Optional) The unique Id of the email template to use when a family request is made.
+    - `maximum_child_age` - (Optional) The maximum age of a child. Value must be greater than 0.
+    - `minimum_owner_age` - (Optional) The minimum age to be an owner. Value must be greater than 0.
+    - `parent_email_required` - (Optional) Whether a parent email is required.
+    - `parent_registration_email_template_id` - (Optional) The unique Id of the email template to use for parent registration.
+* `form_configuration` - (Optional)
+    - `admin_user_form_id` - (Optional) The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI.
+* `http_session_max_inactive_interval` - (Optional) Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
+* `issuer` - (Required) The named issuer used to sign tokens, this is generally your public fully qualified domain.
+* `jwt_configuration` - (Required)
+    - `access_token_key_id` - (Optional) The unique id of the signing key used to sign the access token. Required prior to `1.30.0`.
+    - `id_token_key_id` - (Optional) The unique id of the signing key used to sign the Id token. Required prior to `1.30.0`.
+    - `refresh_token_expiration_policy` - (Optional) The refresh token expiration policy.
+    - `refresh_token_revocation_policy_on_login_prevented` - (Optional) When enabled, the refresh token will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
+    - `refresh_token_revocation_policy_on_password_change` - (Optional) When enabled, the refresh token will be revoked when a user changes their password."
+    - `refresh_token_time_to_live_in_minutes` - (Required) The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
+    - `refresh_token_usage_policy` - (Optional) The refresh token usage policy.
+    - `time_to_live_in_seconds` - (Required) The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.
+* `login_configuration`
+    - `require_authentication` - (Optional) Indicates whether to require an API key for the Login API when an `applicationId` is not provided. When an `applicationId` is provided to the Login API call, the application configuration will take precedence. In almost all cases, you will want to this to be `true`.
+* `logout_url` - (Optional) The logout redirect URL when sending the user’s browser to the /oauth2/logout URI of the FusionAuth Front End. This value is only used when a logout URL is not defined in your Application.
+* `maximum_password_age` - (Optional)
+    - `days` - (Optional) The password maximum age in days. The number of days after which FusionAuth will require a user to change their password. Required when systemConfiguration.maximumPasswordAge.enabled is set to true.
+    - `enabled` - (Optional) Indicates that the maximum password age is enabled and being enforced.
+* `minimum_password_age` - (Optional)
+    - `seconds` - (Optional) The password minimum age in seconds. When enabled FusionAuth will not allow a password to be changed until it reaches this minimum age. Required when systemConfiguration.minimumPasswordAge.enabled is set to true.
+    - `enabled` - (Optional) Indicates that the minimum password age is enabled and being enforced.
+* `multi_factor_configuration` - (Optional)
+    - `login_policy` - (Optional)  When set to `Enabled` and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to `Disabled`, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.
+    - `authenticator` - (Optional)
+        * `enabled` - (Optional) When enabled, users may utilize an authenticator application to complete a multi-factor authentication request. This method uses TOTP (Time-Based One-Time Password) as defined in RFC 6238 and often uses an native mobile app such as Google Authenticator.
+    - `email` - (Optional)
+        * `enabled` - (Optional) When enabled, users may utilize an email address to complete a multi-factor authentication request.
+        * `template_id` - (Optional) The Id of the email template that is used when notifying a user to complete a multi-factor authentication request.
+    - `sms` - (Optional)
+        * `enabled` - (Optional) When enabled, users may utilize a mobile phone number to complete a multi-factor authentication request.
+        * `messenger_id` - (Optional) The messenger that is used to deliver a SMS multi-factor authentication request.
+        * `template_id` - (Optional) The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
+* `name` - (Required) The unique name of the Tenant.
+* `oauth_configuration` - (Optional)
+    - `client_credentials_access_token_populate_lambda_id` - (Optional) The Id of a lambda that will be called to populate the JWT during a client credentials grant. **Note:** A paid edition of FusionAuth is required to utilize client credentials grant.
+* `password_encryption_configuration` - (Optional)
+    - `encryption_scheme` - (Optional) The default method for encrypting the User’s password.
+    - `encryption_scheme_factor` - (Optional) The factor used by the password encryption scheme. If not provided, the PasswordEncryptor provides a default value. Generally this will be used as an iteration count to generate the hash. The actual use of this value is up to the PasswordEncryptor implementation.
+    - `modify_encryption_scheme_on_login` - (Optional) When enabled a user’s hash configuration will be modified to match these configured settings. This can be useful to increase a password hash strength over time or upgrade imported users to a more secure encryption scheme after an initial import.
+* `password_validation_rules` - (Optional)
+    - `breach_detection` - (Optional)
+        - `enabled` - (Optional) Whether to enable Reactor breach detection. Requires an activated license.
+        - `match_mode` - (Optional) The level of severity where Reactor will consider a breach.
+        - `notify_user_email_template_id` - (Optional) The Id of the email template to use when notifying user of breached password. Required if tenant.passwordValidationRules.breachDetection.onLogin is set to NotifyUser.
+        - `on_login` - (Optional) The behavior when detecting breaches at time of user login
+    - `max_length` - (Optional) The maximum length of a password when a new user is created or a user requests a password change.
+    - `min_length` - (Optional) The minimum length of a password when a new user is created or a user requests a password change.
+    - `remember_previous_passwords` - (Optional)
+        - `count` - (Optional) The number of previous passwords to remember. Value must be greater than 0.
+        - `enabled` - (Optional) Whether to prevent a user from using any of their previous passwords.
+    - `required_mixed_case` - (Optional) Whether to force the user to use at least one uppercase and one lowercase character.
+    - `require_non_alpha` - (Optional) Whether to force the user to use at least one non-alphanumeric character.
+    - `require_number` - (Optional) Whether to force the user to use at least one number.
+    - `validate_on_login` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
+* `rate_limit_configuration` - (Optional)
+    - `failed_login` - (Optional)
+      - `enabled` -  (Optional) Whether rate limiting is enabled for failed login.
+      - `limit` -  (Optional) The number of times a user can fail to login within the configured timePeriodInSeconds duration. If a Failed authentication action has been configured then it will take precedence.
+      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can fail login before being rate limited. 
+* `theme_id` - (Required) The unique Id of the theme to be used to style the login page and other end user templates.
+* `username_configuration` - (Optional)
+    - `unique` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
+        * `enabled` - (Optional) When true, FusionAuth will handle username collisions by generating a random suffix.
+        * `number_of_digits` - (Optional) The maximum number of digits to use when building a unique suffix for a username. A number will be randomly selected and will be 1 or more digits up to this configured value in length. For example, if this value is 5, the suffix will be a number between 00001 and 99999, inclusive.
+        * `separator` - (Optional) A single character to use as a separator from the requested username and a unique suffix that is added when a duplicate username is detected. This value can be a single non-alphanumeric ASCII character.
+        * `strategy` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
+* `user_delete_policy` - (Optional)
+    - `unverified_enabled` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
+    - `unverified_number_of_days_to_retain` - (Optional)

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -241,11 +241,11 @@ resource "fusionauth_tenant" "example" {
     }
   }
   captcha_configuration {
-    enabled    		  = true
+    enabled         = true
     captcha_method  = "GoogleRecaptchaV3"
-    site_key   		  = "captcha_site_key"
-    secret_key 		  = "captcha_secret_key"
-    threshold  		  = 0.5
+    site_key        = "captcha_site_key"
+    secret_key      = "captcha_secret_key"
+    threshold       = 0.5
   }
   theme_id = fusionauth_theme.example_theme.id
   user_delete_policy {
@@ -256,7 +256,6 @@ resource "fusionauth_tenant" "example" {
 ```
 
 ## Argument Reference
-
 * `source_tenant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
 * `tenant_id` - (Optional) The Id to use for the new Tenant. If not specified a secure random UUID will be generated.
 * `access_control_configuration` - (Optiona)

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -240,6 +240,13 @@ resource "fusionauth_tenant" "example" {
       time_period_in_seconds = 60
     }
   }
+  captcha_configuration {
+    enabled    		  = true
+    captcha_method  = "GoogleRecaptchaV3"
+    site_key   		  = "captcha_site_key"
+    secret_key 		  = "captcha_secret_key"
+    threshold  		  = 0.5
+  }
   theme_id = fusionauth_theme.example_theme.id
   user_delete_policy {
     unverified_enabled                  = false
@@ -249,181 +256,183 @@ resource "fusionauth_tenant" "example" {
 ```
 
 ## Argument Reference
-* `source_tenant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
-* `tenant_id` - (Optional) The Id to use for the new Tenant. If not specified a secure random UUID will be generated.
-* `access_control_configuration` - (Optiona)
-    - `ui_ip_access_control_list_id` - (Optional) The Id of the IP Access Control List limiting access to all applications in this tenant.
-* `captcha_configuration` - (Optiona)
-    - `enabled` - (Optional) Whether captcha configuration is enabled.
-    - `secret_key` - (Optional) The secret key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
-    - `site_key` - (Optional) The site key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
-    - `threshold` - (Optional) The numeric threshold which separates a passing score from a failing one. This value only applies if using either the Google v3 or HCaptcha Enterprise method, otherwise this value is ignored.
-* `connector_policy` - (Optional) A list of Connector policies. Users will be authenticated against Connectors in order. Each Connector can be included in this list at most once and must exist.
-    - `connector_id` - (Optional) The identifier of the Connector to which this policy refers.
-    - `domains` - (Optional) A list of email domains to which this connector should apply. A value of ["*"] indicates this connector applies to all users.
-    - `migrate` - (Optional) If true, the user’s data will be migrated to FusionAuth at first successful authentication; subsequent authentications will occur against the FusionAuth datastore. If false, the Connector’s source will be treated as authoritative.
-* `data` - (Optional) An object that can hold any information about the Tenant that should be persisted.
-* `email_configuration` - (Required)
-    - `additional_headers` - (Optional) The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
-    - `email_update_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
-    - `email_verified_email_template_id` - (Optional) The Id of the Email Template used to verify user emails.
-    - `host` - (Required) The host name of the SMTP server that FusionAuth will use.
-    - `implicit_email_verification_allowed` - (Optional) When set to true, this allows email to be verified as a result of completing a similar email based workflow such as change password. When seto false, the user must explicitly complete the email verification workflow even if the user has already completed a similar email workflow such as change password.
-    - `login_id_in_use_on_create_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
-    - `login_id_in_use_on_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
-    - `login_new_device_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they log in on a new device.
-    - `login_suspicious_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a suspicious login occurs.
-    - `password_reset_success_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password habeen reset.
-    - `password_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password has been rese
-    - `default_from_name` - (Optional) The default From Name used in sending emails when a from name is not provided on an individual email template. This is the display name part of the email address ( i.e. Jared Dunn <jared@piedpiper.com>).
-    - `default_from_email` - (Optional) The default email address that emails will be sent from when a from address is not provided on an individual email template. This is the address part email address (i.e. Jared Dunn <jared@piedpiper.com>).
-    - `forgot_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
-    - `password` - (Optional) An optional password FusionAuth will use to authenticate with the SMTP server.
-    - `passwordless_email_template_id` - (Optional) The Id of the Passwordless Email Template.
-    - `port` - (Required) The port of the SMTP server that FusionAuth will use.
-    - `properties` - (Optional) Additional Email Configuration in a properties file formatted String.
-    - `security` - (Optional) The type of security protocol FusionAuth will use when connecting to the SMTP server.
-    - `set_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user had their account created for them and they must set their password manually and they are sent an email to set their password.
-    - `username` - (Optional) An optional username FusionAuth will to authenticate with the SMTP server.
-    - `verification_email_template_id` - (Optional) The Id of the Email Template that is used to send the verification emails to users. These emails are used to verify that a user’s email address ivalid. If either the verifyEmail or verifyEmailWhenChanged fields are true this field is required.
-    - `verification_strategy` - (Optional) The process by which the user will verify their email address. Possible values are `ClickableLink` or `FormField`.
-    - `verify_email` - (Optional) Whether the user’s email addresses are verified when the registers with your application.
-    - `verify_email_when_changed` - (Optional) Whether the user’s email addresses are verified when the user changes them.
-    - `two_factor_method_add_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been added to their account.
-    - `two_factor_method_remove_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been removed from their account.
-    - `unverified` - (Optional)
-        - `allow_email_change_when_gated` - (Optional) When this value is set to true, the user is allowed to change their email address when they are gated because they haven’t verified their email address.
-        - `behavior` = (Optional) The behavior when detecting breaches at time of user login
-* `event_configuration` - (Optional)
-    - `event` - (Optional) The event type
-    - `enabled` - (Optional) Whether or not FusionAuth should send these types of events to any configured Webhooks.
-    - `transaction_type` - (Optional) The transaction type that FusionAuth uses when sending these types of events to any configured Webhooks.
-* `external_identifier_configuration` - (Required)
-    - `authorization_grant_id_time_to_live_in_seconds` - (Required) The time in seconds until a OAuth authorization code in no longer valid to be exchanged for an access token. This is essentially the time allowed between the start of an Authorization request during the Authorization code grant and when you request an access token using this authorization code on the Token endpoint.
-    - `change_password_id_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the change password Id.
-        - `type` - (Required) The type of the secure generator used for generating the change password Id.
-    - `change_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
-    - `device_code_time_to_live_in_seconds` - (Required) The time in seconds until a device code Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
-    - `device_user_code_id_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the change password Id.
-        - `type` - (Required) The type of the secure generator used for generating the change password Id.
-    - `email_verification_id_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the change password Id.
-        - `type` - (Required) The type of the secure generator used for generating the change password Id.
-    - `email_verification_one_time_code_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the email verification one time code.
-        - `type` - (Optional) The type of the secure generator used for generating the email verification one time code.
-    - `email_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a email verification Id is no longer valid and cannot be used by the Verify Email API. Value must be greater than 0.
-    - `external_authentication_id_time_to_live_in_seconds` - (Required) The time in seconds until an external authentication Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
-    - `one_time_password_time_to_live_in_seconds` - (Required) The time in seconds until a One Time Password is no longer valid and cannot be used by the Login API. Value must be greater than 0.
-    - `passwordless_login_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the change password Id.
-        - `type` - (Required) The type of the secure generator used for generating the change password Id.
-    - `passwordless_login_time_to_live_in_seconds` - (Required) The time in seconds until a passwordless code is no longer valid and cannot be used by the Passwordless API. Value must be greater than 0.
-    - `registration_verification_id_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the change password Id.
-        - `type` - (Required) The type of the secure generator used for generating the change password Id.
-    - `registration_verification_one_time_code_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the registration verification one time code.
-        - `type` - (Optional) The type of the secure generator used for generating the registration verification one time code.
-    - `registration_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
-    - `saml_v2_authn_request_id_ttl_seconds` - (Optional) The time in seconds that a SAML AuthN request will be eligible for use to authenticate with FusionAuth.
-    - `setup_password_id_generator` - (Required)
-        - `length` - (Required) The length of the secure generator used for generating the change password Id.
-        - `type` - (Required) The type of the secure generator used for generating the change password Id.
-    - `setup_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a setup password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
-    - `two_factor_id_time_to_live_in_seconds` - (Required) The time in seconds until a two factor Id is no longer valid and cannot be used by the Two Factor Login API. Value must be greater than 0.
-    - `trust_token_time_to_live_in_seconds` - (Optional) The number of seconds before the Trust Token is no longer valid to complete a request that requires trust. Value must be greater than 0.
-    - `pending_account_link_time_to_live_in_seconds` - (Optional) The number of seconds before the pending account link identifier is no longer valid to complete an account link request. Value must be greater than 0.
-    - `two_factor_trust_id_time_to_live_in_seconds` - (Require) The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication during the next authentication attempt. Value must be greater than 0.
-    - `two_factor_one_time_code_id_generator` - (Required)
-        - `length` - (Required) TThe length of the secure generator used for generating the the two factor code Id.
-        - `type` - (Optional) The type of the secure generator used for generating the two factor one time code Id.
-* `failed_authentication_configuration` - (Optional)
-    - `action_duration` - (Required) The duration of the User Action. This value along with the actionDurationUnit will be used to set the duration of the User Action. Value must be greater than 0.
-    - `action_duration_unit` - (Optional) The unit of time associated with a duration.
-    - `reset_count_in_seconds` - (Optional) The length of time in seconds before the failed authentication count will be reset. Value must be greater than 0.
-    - `too_many_attempts` - (Optional) The number of failed attempts considered to be too many. Once this threshold is reached the specified User Action will be applied to the user for the duration specified. Value must be greater than 0.
-    - `user_action_id` - (Optional) The Id of the User Action that is applied when the threshold is reached for too many failed authentication attempts.
-* `family_configuration` - (Optional)
-    - `allow_child_registrations` - (Optional) Whether to allow child registrations.
-    - `confirm_child_email_template_id` - (Optional) The unique Id of the email template to use when confirming a child.
-    - `delete_orphaned_accounts` - (Optional) Indicates that child users without parental verification will be permanently deleted after tenant.familyConfiguration.deleteOrphanedAccountsDays days.
-    - `delete_orphaned_accounts_days` - (Optional) The number of days from creation child users will be retained before being deleted for not completing parental verification. Value must be greater than 0.
-    - `enabled` - (Optional) Whether family configuration is enabled.
-    - `family_request_email_template_id` - (Optional) The unique Id of the email template to use when a family request is made.
-    - `maximum_child_age` - (Optional) The maximum age of a child. Value must be greater than 0.
-    - `minimum_owner_age` - (Optional) The minimum age to be an owner. Value must be greater than 0.
-    - `parent_email_required` - (Optional) Whether a parent email is required.
-    - `parent_registration_email_template_id` - (Optional) The unique Id of the email template to use for parent registration.
-* `form_configuration` - (Optional)
-    - `admin_user_form_id` - (Optional) The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI.
-* `http_session_max_inactive_interval` - (Optional) Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
-* `issuer` - (Required) The named issuer used to sign tokens, this is generally your public fully qualified domain.
-* `jwt_configuration` - (Required)
-    - `access_token_key_id` - (Optional) The unique id of the signing key used to sign the access token. Required prior to `1.30.0`.
-    - `id_token_key_id` - (Optional) The unique id of the signing key used to sign the Id token. Required prior to `1.30.0`.
-    - `refresh_token_expiration_policy` - (Optional) The refresh token expiration policy.
-    - `refresh_token_revocation_policy_on_login_prevented` - (Optional) When enabled, the refresh token will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
-    - `refresh_token_revocation_policy_on_password_change` - (Optional) When enabled, the refresh token will be revoked when a user changes their password."
-    - `refresh_token_time_to_live_in_minutes` - (Required) The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
-    - `refresh_token_usage_policy` - (Optional) The refresh token usage policy.
-    - `time_to_live_in_seconds` - (Required) The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.
-* `login_configuration`
-    - `require_authentication` - (Optional) Indicates whether to require an API key for the Login API when an `applicationId` is not provided. When an `applicationId` is provided to the Login API call, the application configuration will take precedence. In almost all cases, you will want to this to be `true`.
-* `logout_url` - (Optional) The logout redirect URL when sending the user’s browser to the /oauth2/logout URI of the FusionAuth Front End. This value is only used when a logout URL is not defined in your Application.
-* `maximum_password_age` - (Optional)
-    - `days` - (Optional) The password maximum age in days. The number of days after which FusionAuth will require a user to change their password. Required when systemConfiguration.maximumPasswordAge.enabled is set to true.
-    - `enabled` - (Optional) Indicates that the maximum password age is enabled and being enforced.
-* `minimum_password_age` - (Optional)
-    - `seconds` - (Optional) The password minimum age in seconds. When enabled FusionAuth will not allow a password to be changed until it reaches this minimum age. Required when systemConfiguration.minimumPasswordAge.enabled is set to true.
-    - `enabled` - (Optional) Indicates that the minimum password age is enabled and being enforced.
-* `multi_factor_configuration` - (Optional)
-    - `login_policy` - (Optional)  When set to `Enabled` and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to `Disabled`, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.
-    - `authenticator` - (Optional)
-        * `enabled` - (Optional) When enabled, users may utilize an authenticator application to complete a multi-factor authentication request. This method uses TOTP (Time-Based One-Time Password) as defined in RFC 6238 and often uses an native mobile app such as Google Authenticator.
-    - `email` - (Optional)
-        * `enabled` - (Optional) When enabled, users may utilize an email address to complete a multi-factor authentication request.
-        * `template_id` - (Optional) The Id of the email template that is used when notifying a user to complete a multi-factor authentication request.
-    - `sms` - (Optional)
-        * `enabled` - (Optional) When enabled, users may utilize a mobile phone number to complete a multi-factor authentication request.
-        * `messenger_id` - (Optional) The messenger that is used to deliver a SMS multi-factor authentication request.
-        * `template_id` - (Optional) The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
-* `name` - (Required) The unique name of the Tenant.
-* `oauth_configuration` - (Optional)
-    - `client_credentials_access_token_populate_lambda_id` - (Optional) The Id of a lambda that will be called to populate the JWT during a client credentials grant. **Note:** A paid edition of FusionAuth is required to utilize client credentials grant.
-* `password_encryption_configuration` - (Optional)
-    - `encryption_scheme` - (Optional) The default method for encrypting the User’s password.
-    - `encryption_scheme_factor` - (Optional) The factor used by the password encryption scheme. If not provided, the PasswordEncryptor provides a default value. Generally this will be used as an iteration count to generate the hash. The actual use of this value is up to the PasswordEncryptor implementation.
-    - `modify_encryption_scheme_on_login` - (Optional) When enabled a user’s hash configuration will be modified to match these configured settings. This can be useful to increase a password hash strength over time or upgrade imported users to a more secure encryption scheme after an initial import.
-* `password_validation_rules` - (Optional)
-    - `breach_detection` - (Optional)
-        - `enabled` - (Optional) Whether to enable Reactor breach detection. Requires an activated license.
-        - `match_mode` - (Optional) The level of severity where Reactor will consider a breach.
-        - `notify_user_email_template_id` - (Optional) The Id of the email template to use when notifying user of breached password. Required if tenant.passwordValidationRules.breachDetection.onLogin is set to NotifyUser.
-        - `on_login` - (Optional) The behavior when detecting breaches at time of user login
-    - `max_length` - (Optional) The maximum length of a password when a new user is created or a user requests a password change.
-    - `min_length` - (Optional) The minimum length of a password when a new user is created or a user requests a password change.
-    - `remember_previous_passwords` - (Optional)
-        - `count` - (Optional) The number of previous passwords to remember. Value must be greater than 0.
-        - `enabled` - (Optional) Whether to prevent a user from using any of their previous passwords.
-    - `required_mixed_case` - (Optional) Whether to force the user to use at least one uppercase and one lowercase character.
-    - `require_non_alpha` - (Optional) Whether to force the user to use at least one non-alphanumeric character.
-    - `require_number` - (Optional) Whether to force the user to use at least one number.
-    - `validate_on_login` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
-* `rate_limit_configuration` - (Optional)
-    - `failed_login` - (Optional)
-      - `enabled` -  (Optional) Whether rate limiting is enabled for failed login.
-      - `limit` -  (Optional) The number of times a user can fail to login within the configured timePeriodInSeconds duration. If a Failed authentication action has been configured then it will take precedence.
-      - `time_period_in_seconds` - (Optional) The duration for the number of times a user can fail login before being rate limited. 
-* `theme_id` - (Required) The unique Id of the theme to be used to style the login page and other end user templates.
-* `username_configuration` - (Optional)
-    - `unique` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
-        * `enabled` - (Optional) When true, FusionAuth will handle username collisions by generating a random suffix.
-        * `number_of_digits` - (Optional) The maximum number of digits to use when building a unique suffix for a username. A number will be randomly selected and will be 1 or more digits up to this configured value in length. For example, if this value is 5, the suffix will be a number between 00001 and 99999, inclusive.
-        * `separator` - (Optional) A single character to use as a separator from the requested username and a unique suffix that is added when a duplicate username is detected. This value can be a single non-alphanumeric ASCII character.
-        * `strategy` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
-* `user_delete_policy` - (Optional)
-    - `unverified_enabled` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
-    - `unverified_number_of_days_to_retain` - (Optional)
+
+- `source_tenant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
+- `tenant_id` - (Optional) The Id to use for the new Tenant. If not specified a secure random UUID will be generated.
+- `access_control_configuration` - (Optiona)
+  - `ui_ip_access_control_list_id` - (Optional) The Id of the IP Access Control List limiting access to all applications in this tenant.
+- `captcha_configuration` - (Optiona)
+  - `enabled` - (Optional) Whether captcha configuration is enabled.
+  - `captcha_method` - (Optional) The type of captcha method to use. This field is required when tenant.captchaConfiguration.enabled is set to true.
+  - `secret_key` - (Optional) The secret key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
+  - `site_key` - (Optional) The site key for this captcha method. This field is required when tenant.captchaConfiguration.enabled is set to true.
+  - `threshold` - (Optional) The numeric threshold which separates a passing score from a failing one. This value only applies if using either the Google v3 or HCaptcha Enterprise method, otherwise this value is ignored.
+- `connector_policy` - (Optional) A list of Connector policies. Users will be authenticated against Connectors in order. Each Connector can be included in this list at most once and must exist.
+  - `connector_id` - (Optional) The identifier of the Connector to which this policy refers.
+  - `domains` - (Optional) A list of email domains to which this connector should apply. A value of ["*"] indicates this connector applies to all users.
+  - `migrate` - (Optional) If true, the user’s data will be migrated to FusionAuth at first successful authentication; subsequent authentications will occur against the FusionAuth datastore. If false, the Connector’s source will be treated as authoritative.
+- `data` - (Optional) An object that can hold any information about the Tenant that should be persisted.
+- `email_configuration` - (Required)
+  - `additional_headers` - (Optional) The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
+  - `email_update_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
+  - `email_verified_email_template_id` - (Optional) The Id of the Email Template used to verify user emails.
+  - `host` - (Required) The host name of the SMTP server that FusionAuth will use.
+  - `implicit_email_verification_allowed` - (Optional) When set to true, this allows email to be verified as a result of completing a similar email based workflow such as change password. When seto false, the user must explicitly complete the email verification workflow even if the user has already completed a similar email workflow such as change password.
+  - `login_id_in_use_on_create_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
+  - `login_id_in_use_on_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when another user attempts to create an account with their login Id.
+  - `login_new_device_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they log in on a new device.
+  - `login_suspicious_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a suspicious login occurs.
+  - `password_reset_success_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password habeen reset.
+  - `password_update_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when they have completed a 'forgot password' workflow and their password has been rese
+  - `default_from_name` - (Optional) The default From Name used in sending emails when a from name is not provided on an individual email template. This is the display name part of the email address ( i.e. Jared Dunn <jared@piedpiper.com>).
+  - `default_from_email` - (Optional) The default email address that emails will be sent from when a from address is not provided on an individual email template. This is the address part email address (i.e. Jared Dunn <jared@piedpiper.com>).
+  - `forgot_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
+  - `password` - (Optional) An optional password FusionAuth will use to authenticate with the SMTP server.
+  - `passwordless_email_template_id` - (Optional) The Id of the Passwordless Email Template.
+  - `port` - (Required) The port of the SMTP server that FusionAuth will use.
+  - `properties` - (Optional) Additional Email Configuration in a properties file formatted String.
+  - `security` - (Optional) The type of security protocol FusionAuth will use when connecting to the SMTP server.
+  - `set_password_email_template_id` - (Optional) The Id of the Email Template that is used when a user had their account created for them and they must set their password manually and they are sent an email to set their password.
+  - `username` - (Optional) An optional username FusionAuth will to authenticate with the SMTP server.
+  - `verification_email_template_id` - (Optional) The Id of the Email Template that is used to send the verification emails to users. These emails are used to verify that a user’s email address ivalid. If either the verifyEmail or verifyEmailWhenChanged fields are true this field is required.
+  - `verification_strategy` - (Optional) The process by which the user will verify their email address. Possible values are `ClickableLink` or `FormField`.
+  - `verify_email` - (Optional) Whether the user’s email addresses are verified when the registers with your application.
+  - `verify_email_when_changed` - (Optional) Whether the user’s email addresses are verified when the user changes them.
+  - `two_factor_method_add_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been added to their account.
+  - `two_factor_method_remove_email_template_id` - (Optional) The Id of the Email Template used to send emails to users when a MFA method has been removed from their account.
+  - `unverified` - (Optional)
+    - `allow_email_change_when_gated` - (Optional) When this value is set to true, the user is allowed to change their email address when they are gated because they haven’t verified their email address.
+    - `behavior` = (Optional) The behavior when detecting breaches at time of user login
+- `event_configuration` - (Optional)
+  - `event` - (Optional) The event type
+  - `enabled` - (Optional) Whether or not FusionAuth should send these types of events to any configured Webhooks.
+  - `transaction_type` - (Optional) The transaction type that FusionAuth uses when sending these types of events to any configured Webhooks.
+- `external_identifier_configuration` - (Required)
+  - `authorization_grant_id_time_to_live_in_seconds` - (Required) The time in seconds until a OAuth authorization code in no longer valid to be exchanged for an access token. This is essentially the time allowed between the start of an Authorization request during the Authorization code grant and when you request an access token using this authorization code on the Token endpoint.
+  - `change_password_id_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the change password Id.
+    - `type` - (Required) The type of the secure generator used for generating the change password Id.
+  - `change_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
+  - `device_code_time_to_live_in_seconds` - (Required) The time in seconds until a device code Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
+  - `device_user_code_id_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the change password Id.
+    - `type` - (Required) The type of the secure generator used for generating the change password Id.
+  - `email_verification_id_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the change password Id.
+    - `type` - (Required) The type of the secure generator used for generating the change password Id.
+  - `email_verification_one_time_code_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the email verification one time code.
+    - `type` - (Optional) The type of the secure generator used for generating the email verification one time code.
+  - `email_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a email verification Id is no longer valid and cannot be used by the Verify Email API. Value must be greater than 0.
+  - `external_authentication_id_time_to_live_in_seconds` - (Required) The time in seconds until an external authentication Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.
+  - `one_time_password_time_to_live_in_seconds` - (Required) The time in seconds until a One Time Password is no longer valid and cannot be used by the Login API. Value must be greater than 0.
+  - `passwordless_login_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the change password Id.
+    - `type` - (Required) The type of the secure generator used for generating the change password Id.
+  - `passwordless_login_time_to_live_in_seconds` - (Required) The time in seconds until a passwordless code is no longer valid and cannot be used by the Passwordless API. Value must be greater than 0.
+  - `registration_verification_id_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the change password Id.
+    - `type` - (Required) The type of the secure generator used for generating the change password Id.
+  - `registration_verification_one_time_code_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the registration verification one time code.
+    - `type` - (Optional) The type of the secure generator used for generating the registration verification one time code.
+  - `registration_verification_id_time_to_live_in_seconds` - (Required) The time in seconds until a registration verification Id is no longer valid and cannot be used by the Verify Registration API. Value must be greater than 0.
+  - `saml_v2_authn_request_id_ttl_seconds` - (Optional) The time in seconds that a SAML AuthN request will be eligible for use to authenticate with FusionAuth.
+  - `setup_password_id_generator` - (Required)
+    - `length` - (Required) The length of the secure generator used for generating the change password Id.
+    - `type` - (Required) The type of the secure generator used for generating the change password Id.
+  - `setup_password_id_time_to_live_in_seconds` - (Required) The time in seconds until a setup password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.
+  - `two_factor_id_time_to_live_in_seconds` - (Required) The time in seconds until a two factor Id is no longer valid and cannot be used by the Two Factor Login API. Value must be greater than 0.
+  - `trust_token_time_to_live_in_seconds` - (Optional) The number of seconds before the Trust Token is no longer valid to complete a request that requires trust. Value must be greater than 0.
+  - `pending_account_link_time_to_live_in_seconds` - (Optional) The number of seconds before the pending account link identifier is no longer valid to complete an account link request. Value must be greater than 0.
+  - `two_factor_trust_id_time_to_live_in_seconds` - (Require) The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication during the next authentication attempt. Value must be greater than 0.
+  - `two_factor_one_time_code_id_generator` - (Required)
+    - `length` - (Required) TThe length of the secure generator used for generating the the two factor code Id.
+    - `type` - (Optional) The type of the secure generator used for generating the two factor one time code Id.
+- `failed_authentication_configuration` - (Optional)
+  - `action_duration` - (Required) The duration of the User Action. This value along with the actionDurationUnit will be used to set the duration of the User Action. Value must be greater than 0.
+  - `action_duration_unit` - (Optional) The unit of time associated with a duration.
+  - `reset_count_in_seconds` - (Optional) The length of time in seconds before the failed authentication count will be reset. Value must be greater than 0.
+  - `too_many_attempts` - (Optional) The number of failed attempts considered to be too many. Once this threshold is reached the specified User Action will be applied to the user for the duration specified. Value must be greater than 0.
+  - `user_action_id` - (Optional) The Id of the User Action that is applied when the threshold is reached for too many failed authentication attempts.
+- `family_configuration` - (Optional)
+  - `allow_child_registrations` - (Optional) Whether to allow child registrations.
+  - `confirm_child_email_template_id` - (Optional) The unique Id of the email template to use when confirming a child.
+  - `delete_orphaned_accounts` - (Optional) Indicates that child users without parental verification will be permanently deleted after tenant.familyConfiguration.deleteOrphanedAccountsDays days.
+  - `delete_orphaned_accounts_days` - (Optional) The number of days from creation child users will be retained before being deleted for not completing parental verification. Value must be greater than 0.
+  - `enabled` - (Optional) Whether family configuration is enabled.
+  - `family_request_email_template_id` - (Optional) The unique Id of the email template to use when a family request is made.
+  - `maximum_child_age` - (Optional) The maximum age of a child. Value must be greater than 0.
+  - `minimum_owner_age` - (Optional) The minimum age to be an owner. Value must be greater than 0.
+  - `parent_email_required` - (Optional) Whether a parent email is required.
+  - `parent_registration_email_template_id` - (Optional) The unique Id of the email template to use for parent registration.
+- `form_configuration` - (Optional)
+  - `admin_user_form_id` - (Optional) The unique Id of the form to use for the Add and Edit User form when used in the FusionAuth admin UI.
+- `http_session_max_inactive_interval` - (Optional) Time in seconds until an inactive session will be invalidated. Used when creating a new session in the FusionAuth OAuth frontend.
+- `issuer` - (Required) The named issuer used to sign tokens, this is generally your public fully qualified domain.
+- `jwt_configuration` - (Required)
+  - `access_token_key_id` - (Optional) The unique id of the signing key used to sign the access token. Required prior to `1.30.0`.
+  - `id_token_key_id` - (Optional) The unique id of the signing key used to sign the Id token. Required prior to `1.30.0`.
+  - `refresh_token_expiration_policy` - (Optional) The refresh token expiration policy.
+  - `refresh_token_revocation_policy_on_login_prevented` - (Optional) When enabled, the refresh token will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
+  - `refresh_token_revocation_policy_on_password_change` - (Optional) When enabled, the refresh token will be revoked when a user changes their password."
+  - `refresh_token_time_to_live_in_minutes` - (Required) The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
+  - `refresh_token_usage_policy` - (Optional) The refresh token usage policy.
+  - `time_to_live_in_seconds` - (Required) The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.
+- `login_configuration`
+  - `require_authentication` - (Optional) Indicates whether to require an API key for the Login API when an `applicationId` is not provided. When an `applicationId` is provided to the Login API call, the application configuration will take precedence. In almost all cases, you will want to this to be `true`.
+- `logout_url` - (Optional) The logout redirect URL when sending the user’s browser to the /oauth2/logout URI of the FusionAuth Front End. This value is only used when a logout URL is not defined in your Application.
+- `maximum_password_age` - (Optional)
+  - `days` - (Optional) The password maximum age in days. The number of days after which FusionAuth will require a user to change their password. Required when systemConfiguration.maximumPasswordAge.enabled is set to true.
+  - `enabled` - (Optional) Indicates that the maximum password age is enabled and being enforced.
+- `minimum_password_age` - (Optional)
+  - `seconds` - (Optional) The password minimum age in seconds. When enabled FusionAuth will not allow a password to be changed until it reaches this minimum age. Required when systemConfiguration.minimumPasswordAge.enabled is set to true.
+  - `enabled` - (Optional) Indicates that the minimum password age is enabled and being enforced.
+- `multi_factor_configuration` - (Optional)
+  - `login_policy` - (Optional) When set to `Enabled` and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to `Disabled`, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.
+  - `authenticator` - (Optional)
+    - `enabled` - (Optional) When enabled, users may utilize an authenticator application to complete a multi-factor authentication request. This method uses TOTP (Time-Based One-Time Password) as defined in RFC 6238 and often uses an native mobile app such as Google Authenticator.
+  - `email` - (Optional)
+    - `enabled` - (Optional) When enabled, users may utilize an email address to complete a multi-factor authentication request.
+    - `template_id` - (Optional) The Id of the email template that is used when notifying a user to complete a multi-factor authentication request.
+  - `sms` - (Optional)
+    - `enabled` - (Optional) When enabled, users may utilize a mobile phone number to complete a multi-factor authentication request.
+    - `messenger_id` - (Optional) The messenger that is used to deliver a SMS multi-factor authentication request.
+    - `template_id` - (Optional) The Id of the SMS template that is used when notifying a user to complete a multi-factor authentication request.
+- `name` - (Required) The unique name of the Tenant.
+- `oauth_configuration` - (Optional)
+  - `client_credentials_access_token_populate_lambda_id` - (Optional) The Id of a lambda that will be called to populate the JWT during a client credentials grant. **Note:** A paid edition of FusionAuth is required to utilize client credentials grant.
+- `password_encryption_configuration` - (Optional)
+  - `encryption_scheme` - (Optional) The default method for encrypting the User’s password.
+  - `encryption_scheme_factor` - (Optional) The factor used by the password encryption scheme. If not provided, the PasswordEncryptor provides a default value. Generally this will be used as an iteration count to generate the hash. The actual use of this value is up to the PasswordEncryptor implementation.
+  - `modify_encryption_scheme_on_login` - (Optional) When enabled a user’s hash configuration will be modified to match these configured settings. This can be useful to increase a password hash strength over time or upgrade imported users to a more secure encryption scheme after an initial import.
+- `password_validation_rules` - (Optional)
+  - `breach_detection` - (Optional)
+    - `enabled` - (Optional) Whether to enable Reactor breach detection. Requires an activated license.
+    - `match_mode` - (Optional) The level of severity where Reactor will consider a breach.
+    - `notify_user_email_template_id` - (Optional) The Id of the email template to use when notifying user of breached password. Required if tenant.passwordValidationRules.breachDetection.onLogin is set to NotifyUser.
+    - `on_login` - (Optional) The behavior when detecting breaches at time of user login
+  - `max_length` - (Optional) The maximum length of a password when a new user is created or a user requests a password change.
+  - `min_length` - (Optional) The minimum length of a password when a new user is created or a user requests a password change.
+  - `remember_previous_passwords` - (Optional)
+    - `count` - (Optional) The number of previous passwords to remember. Value must be greater than 0.
+    - `enabled` - (Optional) Whether to prevent a user from using any of their previous passwords.
+  - `required_mixed_case` - (Optional) Whether to force the user to use at least one uppercase and one lowercase character.
+  - `require_non_alpha` - (Optional) Whether to force the user to use at least one non-alphanumeric character.
+  - `require_number` - (Optional) Whether to force the user to use at least one number.
+  - `validate_on_login` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
+- `rate_limit_configuration` - (Optional)
+  - `failed_login` - (Optional)
+    - `enabled` - (Optional) Whether rate limiting is enabled for failed login.
+    - `limit` - (Optional) The number of times a user can fail to login within the configured timePeriodInSeconds duration. If a Failed authentication action has been configured then it will take precedence.
+    - `time_period_in_seconds` - (Optional) The duration for the number of times a user can fail login before being rate limited.
+- `theme_id` - (Required) The unique Id of the theme to be used to style the login page and other end user templates.
+- `username_configuration` - (Optional)
+  - `unique` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
+    - `enabled` - (Optional) When true, FusionAuth will handle username collisions by generating a random suffix.
+    - `number_of_digits` - (Optional) The maximum number of digits to use when building a unique suffix for a username. A number will be randomly selected and will be 1 or more digits up to this configured value in length. For example, if this value is 5, the suffix will be a number between 00001 and 99999, inclusive.
+    - `separator` - (Optional) A single character to use as a separator from the requested username and a unique suffix that is added when a duplicate username is detected. This value can be a single non-alphanumeric ASCII character.
+    - `strategy` - (Optional) When enabled the user’s password will be validated during login. If the password does not meet the currently configured validation rules the user will be required to change their password.
+- `user_delete_policy` - (Optional)
+  - `unverified_enabled` - (Optional) Indicates that users without a verified email address will be permanently deleted after tenant.userDeletePolicy.unverified.numberOfDaysToRetain days.
+  - `unverified_number_of_days_to_retain` - (Optional)

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -55,6 +55,17 @@ func newTenant() *schema.Resource {
 							Default:     false,
 							Description: "Whether captcha configuration is enabled.",
 						},
+						"captcha_method": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"GoogleRecaptchaV2",
+								"GoogleRecaptchaV3",
+								"HCaptcha",
+								"HCaptchaEnterprise",
+							}, false),
+							Description: "The type of captcha method to use. This field is required when tenant.captchaConfiguration.enabled is set to true.",
+						},
 						"secret_key": {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -245,6 +245,13 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 				TimePeriodInSeconds: data.Get("rate_limit_configuration.0.failed_login.0.time_period_in_seconds").(int),
 			},
 		},
+		CaptchaConfiguration: fusionauth.TenantCaptchaConfiguration{
+			Enableable:		buildEnableable("captchaConfiguration.0.enabled", data),
+			CaptchaMethod: 	fusionauth.UnverifiedBehavior(data.Get("captchaConfiguration.0.captcha_method").(string)),
+			SecretKey:		data.Get("captchaConfiguration.0.secret_key").(string),
+			SiteKey:    	data.Get("captchaConfiguration.0.site_key").(string),
+			Threshold:  	data.Get("captchaConfiguration.0.Threshold").(float64),
+		},
 		ThemeId: data.Get("theme_id").(string),
 		UserDeletePolicy: fusionauth.TenantUserDeletePolicy{
 			Unverified: fusionauth.TimeBasedDeletePolicy{

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -246,11 +246,11 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			},
 		},
 		CaptchaConfiguration: fusionauth.TenantCaptchaConfiguration{
-			Enableable:		buildEnableable("captchaConfiguration.0.enabled", data),
-			CaptchaMethod: 	fusionauth.CaptchaMethod(data.Get("captchaConfiguration.0.captcha_method").(string)),
-			SecretKey:		data.Get("captchaConfiguration.0.secret_key").(string),
-			SiteKey:    	data.Get("captchaConfiguration.0.site_key").(string),
-			Threshold:  	data.Get("captchaConfiguration.0.Threshold").(float64),
+			Enableable:		buildEnableable("captcha_configuration.0.enabled", data),
+			CaptchaMethod: 	fusionauth.CaptchaMethod(data.Get("captcha_configuration.0.captcha_method").(string)),
+			SecretKey:		data.Get("captcha_configuration.0.secret_key").(string),
+			SiteKey:    	data.Get("captcha_configuration.0.site_key").(string),
+			Threshold:  	data.Get("captcha_configuration.0.threshold").(float64),
 		},
 		ThemeId: data.Get("theme_id").(string),
 		UserDeletePolicy: fusionauth.TenantUserDeletePolicy{
@@ -597,6 +597,19 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 		return diag.Errorf("tenant.password_encryption_configuration: %s", err.Error())
 	}
 
+	err = data.Set("captcha_configuration", []map[string]interface{}{
+		{
+			"enabled":          t.CaptchaConfiguration.Enabled,
+			"captcha_method":   t.CaptchaConfiguration.CaptchaMethod,
+			"secret_key": 		t.CaptchaConfiguration.SecretKey,
+			"site_key": 		t.CaptchaConfiguration.SiteKey,
+			"threshold": 		t.CaptchaConfiguration.Threshold,
+		},
+	})
+	if err != nil {
+		return diag.Errorf("tenant.captcha_configuration: %s", err.Error())
+	}
+
 	err = data.Set("password_validation_rules", []map[string]interface{}{
 		{
 			"breach_detection": []map[string]interface{}{{
@@ -619,6 +632,19 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 	})
 	if err != nil {
 		return diag.Errorf("tenant.password_validation_rules: %s", err.Error())
+	}
+
+	err = data.Set("rate_limit_configuration", []map[string]interface{}{
+		{
+			"failed_login": []map[string]interface{}{{
+				"enabled":                t.RateLimitConfiguration.FailedLogin.Enabled,
+				"limit":                  t.RateLimitConfiguration.FailedLogin.Limit,
+				"time_period_in_seconds": t.RateLimitConfiguration.FailedLogin.TimePeriodInSeconds,
+			}},
+		},
+	})
+	if err != nil {
+		return diag.Errorf("tenant.rate_limit_configuration: %s", err.Error())
 	}
 
 	if err := data.Set("theme_id", t.ThemeId); err != nil {

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -247,7 +247,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 		},
 		CaptchaConfiguration: fusionauth.TenantCaptchaConfiguration{
 			Enableable:		buildEnableable("captchaConfiguration.0.enabled", data),
-			CaptchaMethod: 	fusionauth.UnverifiedBehavior(data.Get("captchaConfiguration.0.captcha_method").(string)),
+			CaptchaMethod: 	fusionauth.CaptchaMethod(data.Get("captchaConfiguration.0.captcha_method").(string)),
 			SecretKey:		data.Get("captchaConfiguration.0.secret_key").(string),
 			SiteKey:    	data.Get("captchaConfiguration.0.site_key").(string),
 			Threshold:  	data.Get("captchaConfiguration.0.Threshold").(float64),

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -247,6 +247,14 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.limit", "5"),
 		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.time_period_in_seconds", "60"),
 
+		// captcha_configuration
+		resource.TestCheckResourceAttrSet(tfResourcePath, "captcha_configuration"),
+		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.enabled", "true"),
+		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.captcha_method", "GoogleRecaptchaV3"),
+		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.secret_key", "captcha_secret_key"),
+		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.site_key", "captcha_site_key"),
+		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.threshold", "0.5"),
+
 		resource.TestCheckResourceAttrSet(tfResourcePath, "theme_id"),
 
 		// user_delete_policy
@@ -606,6 +614,13 @@ resource "fusionauth_tenant" "test_%[1]s" {
         limit                  = 5
         time_period_in_seconds = 60
     }
+  }
+  captcha_configuration {
+    enabled    		= true
+    captcha_method  = "GoogleRecaptchaV3"
+    site_key   		= "captcha_site_key"
+    secret_key 		= "captcha_secret_key"
+    threshold  		= 0.5
   }
   # theme_id%[2]s
   user_delete_policy {

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -242,13 +242,13 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "password_validation_rules.0.validate_on_login", "true"),
 
 		// rate_limit_configuration
-		resource.TestCheckResourceAttrSet(tfResourcePath, "rate_limit_configuration"),
+		resource.TestCheckResourceAttrSet(tfResourcePath, "rate_limit_configuration.#"),
 		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.enabled", "true"),
 		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.limit", "5"),
 		resource.TestCheckResourceAttr(tfResourcePath, "rate_limit_configuration.0.failed_login.0.time_period_in_seconds", "60"),
 
 		// captcha_configuration
-		resource.TestCheckResourceAttrSet(tfResourcePath, "captcha_configuration"),
+		resource.TestCheckResourceAttrSet(tfResourcePath, "captcha_configuration.#"),
 		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.enabled", "true"),
 		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.captcha_method", "GoogleRecaptchaV3"),
 		resource.TestCheckResourceAttr(tfResourcePath, "captcha_configuration.0.secret_key", "captcha_secret_key"),

--- a/fusionauth/resource_fusionauth_themes_test.go
+++ b/fusionauth/resource_fusionauth_themes_test.go
@@ -210,6 +210,8 @@ func generateFusionAuthTemplate() fusionauth.Templates {
 		Oauth2Register:                            randString20(),
 		Oauth2StartIdPLink:                        randString20(),
 		Oauth2TwoFactor:                           randString20(),
+		Oauth2TwoFactorEnable:                     randString20(),
+		Oauth2TwoFactorEnableComplete:             randString20(),
 		Oauth2TwoFactorMethods:                    randString20(),
 		Oauth2Wait:                                randString20(),
 		Oauth2WebAuthn:                            randString20(),

--- a/fusionauth/testdata/messages.properties.go
+++ b/fusionauth/testdata/messages.properties.go
@@ -10,7 +10,7 @@ func MessageProperties(name string) string {
 
 	return fmt.Sprintf(`
 #
-# Copyright (c) 2019-2021, FusionAuth, All Rights Reserved
+# Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,14 +26,24 @@ func MessageProperties(name string) string {
 #
 
 #
+# Date and Time formats
+#
+date-format=M/d/yyyy
+date-time-format=M/d/yyyy hh:mm a z
+date-time-seconds-format=M/d/yyyy hh:mm:ss a z
+
+#
 # Text used on the page (inside the HTML). You can create new key-value pairs here and use them in the templates.
 #
 access-denied=Access denied
 account=Account
+action=Action
 add-two-factor=Add two-factor
+add-webauthn-passkey=Add passkey
 back-to-login=Return to Login
 cancel=Cancel
 captcha-google-branding=This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+created=Created
 authorized-not-registered=Registration is required to access this application and your account has not been registered for this application. Please complete your registration and try again.
 authorized-not-registered-title=Registration Required
 cancel-link=Cancel link request
@@ -48,13 +58,17 @@ complete-external-login=Complete login on your external device\u2026
 completed-link=You have successfully linked your %s account.
 completed-links=You have successfully linked your %s and %s account.
 confirm=Confirm
+delete-webauthn-passkey=Delete passkey
 device-form-title=Device login
 device-login-complete=Successfully connected device
 device-title=Connect Your Device
 device-link-count-exceeded-next-step=To continue, click the button below. You will be logged out and then redirected here to continue the device login.
 device-link-count-exceeded-pending-logout=You are logged in as %s. No additional links may be made to %s.
+device-logged-in-as-not-you=You are logged in as %s. If you continue, the device login will be completed without an additional prompt. If this is not you, click logout before continuing.
 disable=Disable
+display-name=Display name
 done=Done
+dont-ask-again=Don't ask me again on this device
 dont-have-an-account=Don't have an account?
 edit=Edit
 email-verification-complete=Thank you. Your email has been verified.
@@ -66,6 +80,7 @@ email-verification-sent-title=Verification sent
 email-verification-required-title=Verification required
 email-verification-required-send-another=Send me another email
 enabled=Enabled
+enable=Enable
 forgot-password=Forgot your password? Type in your email address in the form below to reset your password.
 forgot-password-email-sent=We've sent you an email containing a link that will allow you to reset your password. Once you receive the email follow the instructions to change your password.
 forgot-password-email-sent-title=Email sent
@@ -73,27 +88,36 @@ forgot-password-title=Forgot password
 forgot-your-password=Forgot your password?
 help=Help
 instructions=Instructions
+id=Id
 ip-address=IP address
 link-to-existing-user=Link to an existing user
 link-to-new-user=Create a new user
-device-logged-in-as-not-you=You are logged in as %s. If you continue, the device login will be completed without an additional prompt. If this is not you, click logout before continuing.
+last-used=Last used
 link-count-exceeded-next-step=To continue, click the button below. You will be logged out and then redirected here to link to an existing user or create a new user.
 link-count-exceeded-next-step-no-registration=To continue, click the button below. You will be logged out and then redirect here to link to an existing user.
 link-count-exceeded-pending-logout=You have already linked to %s and no additional links are allowed.
 logged-in-as=You are logged in as %s.
 login=Login
 login-cancel-link=Or, cancel the link request.
+login-with-passkey=Login with passkey
 logout=Logout
 logout-and-continue=Logout and continue\u2026
 logging-out=Logging out\u2026
 logout-title=Logging out
-multi-factor-configuration=Multi-Factor configuration
+manage-webauthn-passkeys=Manage passkeys
+method=Method
+multi-factor-configuration=Two-Factor configuration
 next=Next
+no-password=No password
+no-webauthn-passkeys=No passkeys have been registered
+no-webauthn-support=This browser does not support WebAuthn passkeys. You may still manage existing passkeys.
 not-configured=Not configured
+not-now=Not now
 note=Note:
 or=Or
 parent-notified=We've sent an email to your parent. They can set up an account for you once they receive it.
 parent-notified-title=Parent notified
+passkeys=Passkeys
 password-alpha-constraint=Must contain at least one non-alphanumeric character
 password-case-constraint=Must contain both upper and lower case characters
 password-change-title=Update your password
@@ -125,25 +149,36 @@ registration-verification-sent=We have sent an email to %s with your verificatio
 registration-verification-sent-title=Verification sent
 registration-verification-required-title=Verification required
 registration-verification-required-send-another=Send me another email
+relying-party-id=Relying party Id
 return-to-login=Return to login
+return-to-normal-login=Return to the normal login
+return-to-webauthn-reauth=Return to passkey authentication
 send-another-code=Send another code
 send-code-to-phone=Send a code to your mobile phone
 set-up=Set up
+signature-count=Signature count
 sms=SMS
 sign-in-as-different-user=Sign in as a different user
 start-idp-link-title=Link your account
 two-factor-challenge=Authentication challenge
 two-factor-challenge-options=Authentication challenge
 two-factor-recovery-code=Recovery code
+two-factor-recovery-codes=Recovery codes
 two-factor-select-method=Didn't receive a code? Try another option
 two-factor-use-one-of-n-recover-codes=Use one of your %d recovery codes
 trust-computer=Trust this computer for %s days
 unauthorized=Unauthorized
 unauthorized-message=You are not authorized to make this request.
 unauthorized-message-blocked-ip=The owner of this website (%s) has blocked your IP address.
+undefined=Undefined
+unnamed=Unnamed
 value=Value
 wait-title=Complete login on your external device
 waiting=Waiting
+warning=Warning
+webauthn-button-text=Fingerprint, device or key
+webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above click "Return to normal login" below.
+webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 
 # Locale Specific separators, etc
 #  - list separator - comma and a space
@@ -203,10 +238,11 @@ user.timezone=Timezone
 user.username=Username
 
 #
-# Self service account management
+# Self-service account management
 #
 cancel-go-back=Cancel and go back
 change-password=Change password
+current-password=Current password
 disable-instructions=Disable two-factor
 disable-two-factor=Disable two-factor
 edit-profile=Edit profile
@@ -216,14 +252,20 @@ go-back=Go back
 send-one-time-code=Send a one-time code
 
 #
-# Self service two-factor configuration
+# Self-service two-factor configuration
 #
 no-two-factor-methods-configured=No methods have been configured
 select-two-factor-method=Select a method
 two-factor-authentication=Two-factor authentication
 two-factor-method=Method
+two-factor-method-authenticator=Authenticator
+two-factor-method-email=Email message
+two-factor-method-sms=Text message
+two-factor-get-code-at-authenticator=Get a code from your authenticator app
+two-factor-get-code-at-email=Get a code at %s\u2026
+two-factor-get-code-at-sms=Get a code at (***) ***-**%s
 
-# Form input place holders
+# Form input place-holders
 {placeholder}two-factor-code=Enter the one-time code
 
 #
@@ -235,14 +277,17 @@ authenticator=Authenticator app
 authenticator-disable-step-1=Enter the code from your authenticator app in the verification code field below to disable this two-factor method.
 authenticator-enable-step-1=Open your authentication app and add your account by scanning the QR code to the right or by manually entering the Base32 encoded secret <strong>%s</strong>.
 authenticator-enable-step-2=Once you have completed the first step, enter the code from your authenticator app in the verification code field below.
+oauth2-authenticator-enable-step-1=Open your authentication app and scan the QR code. Then enter the code from your authenticator app in the form below.
 
 # Email Enable / Disable
 email-disable-step-1=To disable two-factor using email, click the button to send a one-time use code to %s. Once you receive the code, enter it in the form below.
 email-enable-step-1=To enable two-factor using email, enter an email address and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
+oauth2-email-enable-step-1=To enable two-factor using email, enter an email address and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
 
 # SMS Enable / Disable
 sms-disable-step-1=To disable two-factor using SMS, click the button to send a one-time use code to %s. Once you receive the code, enter it in the form below.
 sms-enable-step-1=Two enable two-factor using SMS, enter a mobile phone and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
+oauth2-sms-enable-step-1=Two enable two-factor using SMS, enter a mobile phone and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
 
 authenticator-configuration=Authenticator configuration
 verification-code=Verification code
@@ -258,6 +303,8 @@ go-back-to-send=Go back to send
 {description}two-factor-recovery-code-note=If you no longer have access to the device or application to obtain a verification code, you may use a recovery code to disable this two-factor method. Warning, when you use a recovery code to disable any two-factor method, all two-factor methods will be removed and all of your recovery codes will be cleared.
 {description}recovery-codes-1=Because this is the first time you have enabled two-factor, we have generated you %d recovery codes. These codes will not be shown again, so record them right now and store them in a safe place. These codes can be used to complete a two-factor login if you lose your device, and they can be used to disable two-factor authentication as well.
 {description}recovery-codes-2=Once you have recorded the codes, click Done to return to two-factor management.
+{description}oauth2-recovery-codes-1=Record these recovery codes, they will not be shown again. Recovery codes can be used to complete a two-factor login or disable two-factor authentication if you lose your device.
+{description}oauth2-recovery-codes-2=Once you have recorded the codes, click Done to continue.
 
 {description}email-verification-required-change-email=Confirm your email address is correct and update it if you mis-typed it during registration. Updating your address will also send you a new email to the new address.
 {description}email-verification-required=You must verify your email address before you continue.
@@ -266,8 +313,17 @@ go-back-to-send=Go back to send
 {description}registration-verification-required=You must verify your registration before you continue.
 {description}registration-verification-required-non-interactive=Registration verification is configured to be completed outside of this request. Once you have verified your registration, retry this request.
 
+# WebAuthn
+{description}add-webauthn=Enter a name for this passkey. This name may be used to identify the passkey during a login attempt, or when multiple passkeys exist.
+{description}delete-webauthn-passkey=Click delete to remove the passkey. Once removed, you will no longer be able to use this passkey to complete authentication.
+{description}webauthn-bootstrap-retrieve-credential=Retrieve your previously configured passkeys by entering your email.
+{description}webauthn-passkeys=Passkeys allow you to securely authenticate without a password. Configure one or more passkeys in order to complete authentication.
+{description}webauthn-reauth=Do you want to skip the password next time?
+{description}webauthn-reauth-existing-credential=You can select an existing passkey from the list below and skip the password on your next login.
+{description}webauthn-reauth-add-credential=Register a new passkey. Enter a display name to uniquely identify this key. For example, "Chrome Touch ID".
+
 #
-# Custom Self Service User form sections.
+# Custom Self-service User form sections.
 #
 # - Names are optional, and if not provided they will be labeled 'Section 1', 'Section 2', etc.
 # - The first section label will be omitted unless you specify a named label below. For your convenience, these
@@ -289,7 +345,7 @@ go-back-to-send=Go back to send
 # Custom Admin User and Registration form sections.
 #
 # - Names are optional, and if not provided they will be labeled 'Section 1', 'Section 2', etc.
-# - The first section label on the User and and Registration form in the admin UI will be omitted unless
+# - The first section label on the User and Registration form in the admin UI will be omitted unless
 #   you specify a named label below. For your convenience, these sections are configured below and commented out as 'Optionally name me!'.
 #
 # - By default, all section labels will be used for all tenants, and all applications respectively.
@@ -324,6 +380,11 @@ go-back-to-send=Go back to send
 [confirm]user.password=Confirm password
 
 #
+# Self-service account validation errors
+#
+[invalid]currentPassword=Current password is incorrect
+
+#
 # Default validation errors. Add custom messages by adding field messages.
 # For example, to provide a custom message for a string field named user.data.companyName, add the
 # following message key: [blank]user.data.companyName=Company name is required
@@ -341,6 +402,8 @@ go-back-to-send=Go back to send
 [missing]=Required
 [mismatch]=Unexpected value
 [notEmail]=Invalid email
+[notConfigured]=Not configured
+[previouslyUsed]=Previously used
 [tooLong]=Too long
 [tooShort]=Too short
 [type]=Invalid type
@@ -356,10 +419,11 @@ go-back-to-send=Go back to send
 # Validation errors when forms are invalid. The format is [<error-code>]<field-name>. These are hard-coded in the FusionAuth code and the
 # keys cannot be changed. You can still change the values though.
 #
-[invalid]applicationId=The provided application id is invalid.
+[invalid]applicationId=The provided application Id is invalid.
 [blank]code=Required
 [invalid]code=Invalid code
 [blank]email=Required
+[duplicate]email=An account already exists for that email
 [blank]loginId=Required
 [blank]methodId=Select a two-factor method
 [blank]parentEmail=Required
@@ -397,9 +461,11 @@ go-back-to-send=Go back to send
 [doNotMatch]user.password=Passwords don't match
 [singleCase]user.password=Password must use upper and lowercase characters
 [onlyAlpha]user.password=Password must contain a punctuation character
+[previouslyUsed]user.password=Password has been recently used
 [requireNumber]user.password=Password must contain a number character
 [tooShort]user.password=Password does not meet the minimum length requirement
 [tooLong]user.password=Password exceeds the maximum length requirement
+[tooYoung]user.password=Password was changed too recently, try again later
 [blank]user.username=Required
 [duplicate]user.username=An account already exists for that username
 [inactive]user.username=An account already exists for that username but is locked. Contact the administrator for assistance
@@ -435,6 +501,7 @@ go-back-to-send=Go back to send
 [EmailVerificationSent]=A verification email is on the way.
 [EmailVerificationDisabled]=Email verification functionality is currently disabled. Contact your FusionAuth administrator for assistance.
 [ErrorException]=An unexpected error occurred.
+[ExternalAuthenticationExpired]=Your external authentication request has expired, please re-attempt authentication.
 [ForgotPasswordDisabled]=Forgot password handling is not enabled. Please contact your system administrator for assistance.
 [IdentityProviderDoesNotSupportRedirect]=This identity provider does not support this redirect workflow.
 [InvalidChangePasswordId]=Your password reset code has expired or is invalid. Please retry your request.
@@ -444,6 +511,9 @@ go-back-to-send=Go back to send
 [InvalidPasswordlessLoginId]=Your link has expired or is invalid. Please retry your request.
 [InvalidVerificationId]=Sorry. The request contains an invalid or expired verification Id. You may need to request another verification to be sent.
 [InvalidPendingIdPLinkId]=Your link has expired or is invalid. Please retry your login request.
+[InvalidWebAuthnAuthenticatorResponse]=The response from the WebAuthn authenticator could not be parsed or failed validation.
+[InvalidWebAuthnBrowserResponse]=The WebAuthn response from the browser could not be parsed or failed validation.
+[InvalidWebAuthnLoginId]=Your signature has expired or is invalid. Please retry your request.
 [LinkCountExceeded]=You have reached the configured link limit of %d for this identity provider.
 [LoginPreventedException]=Your account has been locked.
 [LoginPreventedExceptionTooManyTwoFactorAttempts]=You have exceeded the number of allowed attempts. Your account has been locked.
@@ -467,12 +537,16 @@ go-back-to-send=Go back to send
 [RegistrationVerificationSent]=A verification email is on the way.
 [SSOSessionDeletedOrExpired]=You have been logged out of FusionAuth.
 [TenantIdRequired]=FusionAuth is unable to determine which tenant to use for this request. Please add the tenantId to the URL as a request parameter.
+[TwoFactorEnableFailed]=Oops. Something didn't go as planned. Try to complete login again.
+[TwoFactorRequired]=You must configure two-factor in order to continue.
 [TwoFactorTimeout]=You did not complete the two-factor challenge in time. Please complete login again.
 [UserAuthorizedNotRegisteredException]=Your account has not been registered for this application.
 [UserExpiredException]=Your account has expired. Please contact your system administrator.
 [UserLockedException]=Your account has been locked. Please contact your system administrator.
 [UserUnauthenticated]=Oops. It looks like you've gotten here by accident. Please return to your application and log in to begin the authorization sequence.
-[ExternalAuthenticationExpired]=Your external authentication request has expired, please re-attempt authentication.
+[WebAuthnDisabled]=WebAuthn is not currently enabled.
+[WebAuthnCredentialSelectionCanceled]=Passkey selection canceled.
+[WebAuthnFailed]=Unable to complete the WebAuthn workflow.
 
 # External authentication errors
 # - Some of these errors are development time issues. But it is possible they could be shown to an end user depending upon your configuration.
@@ -513,6 +587,7 @@ go-back-to-send=Go back to send
 [ExternalAuthenticationException]SonyPSNToken=A request to the Sony PlayStation Network Token API has failed. Unable to complete this login request.
 [ExternalAuthenticationException]SonyPSNUserInfo=A request to the Sony PlayStation Network User Info API has failed. Unable to complete this login request.
 [ExternalAuthenticationException]SteamPlayerSummary=A request to the Steam Player summary API has failed. Unable to complete this login request.
+[ExternalAuthenticationException]SteamAuthenticateUserTicket=A request to the Steam Authenticate User Ticket API has failed. Unable to complete this login request.
 [ExternalAuthenticationException]SteamToken=A request to the Steam Token API has failed. Unable to complete this login request.
 [ExternalAuthenticationException]TwitchToken=A request to the Twitch Token API has failed. Unable to complete this login request.
 [ExternalAuthenticationException]TwitchUserInfo=A request to the Twitch User Info API has failed. Unable to complete this login request.
@@ -533,7 +608,8 @@ go-back-to-send=Go back to send
 # Webhook transaction failure
 [WebhookTransactionException]=One or more webhooks returned an invalid response or were unreachable. Based on your transaction configuration, your action cannot be completed.
 
-# Self Service
+# Self-service
+[SelfServiceCustomValidationException]=Extended verification has failed. Self-service registration cannot be completed.
 [SelfServiceFormNotConfigured]=Configuration is incomplete. The FusionAuth administrator must configure a form for this application.
 [SelfServiceUserNotRegisteredException]=You are not registered for this application. Not all features will be available.
 [TwoFactorAuthenticationMethodDisabled]=Two-factor authentication has been disabled


### PR DESCRIPTION
Update Fusionauth provider to support tenant captcha configuration.

Note: In order to make `tenant` unit tests working, we had to update some other non-related properties (was taken from https://github.com/gpsinsight/terraform-provider-fusionauth/pull/216).

## Context
[Tenant APIs](https://fusionauth.io/docs/v1/tech/apis/tenants#create-a-tenant)

## Similar Request
https://github.com/gpsinsight/terraform-provider-fusionauth/pull/212