### PR TITLE
feat(resource_fusionauth_tenant): add failed authentication action cancel policy property

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -528,6 +528,7 @@ resource "fusionauth_tenant" "example" {
     - `action_duration_unit` - (Optional) The unit of time associated with a duration.
     - `reset_count_in_seconds` - (Optional) The length of time in seconds before the failed authentication count will be reset. Value must be greater than 0.
     - `too_many_attempts` - (Optional) The number of failed attempts considered to be too many. Once this threshold is reached the specified User Action will be applied to the user for the duration specified. Value must be greater than 0.
+    - `action_cancel_policy_on_password_reset` - (Optional) Indicates whether you want the user to be able to self-service unlock their account prior to the action duration by completing a password reset workflow.
     - `user_action_id` - (Optional) The Id of the User Action that is applied when the threshold is reached for too many failed authentication attempts.
 * `family_configuration` - (Optional)
     - `allow_child_registrations` - (Optional) Whether to allow child registrations.

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -900,6 +900,11 @@ func newFailedAuthenticationConfiguration() *schema.Resource {
 				Default:     "MINUTES",
 				Description: "The unit of time associated with a duration.",
 			},
+			"action_cancel_policy_on_password_reset": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Description:  "Indicates whether you want the user to be able to self-service unlock their account prior to the action duration by completing a password reset workflow.",
+			},
 			"reset_count_in_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -901,9 +901,9 @@ func newFailedAuthenticationConfiguration() *schema.Resource {
 				Description: "The unit of time associated with a duration.",
 			},
 			"action_cancel_policy_on_password_reset": {
-				Type:         schema.TypeBool,
-				Optional:     true,
-				Description:  "Indicates whether you want the user to be able to self-service unlock their account prior to the action duration by completing a password reset workflow.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether you want the user to be able to self-service unlock their account prior to the action duration by completing a password reset workflow.",
 			},
 			"reset_count_in_seconds": {
 				Type:         schema.TypeInt,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -143,6 +143,9 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			ActionDurationUnit: fusionauth.ExpiryUnit(
 				data.Get("failed_authentication_configuration.0.action_duration_unit").(string),
 			),
+			ActionCancelPolicy: fusionauth.FailedAuthenticationActionCancelPolicy{
+				OnPasswordReset:  data.Get("failed_authentication_configuration.0.action_cancel_policy_on_password_reset").(bool),
+			},
 			ResetCountInSeconds: data.Get("failed_authentication_configuration.0.reset_count_in_seconds").(int),
 			TooManyAttempts:     data.Get("failed_authentication_configuration.0.too_many_attempts").(int),
 			UserActionId:        data.Get("failed_authentication_configuration.0.user_action_id").(string),
@@ -481,11 +484,12 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 
 	err = data.Set("failed_authentication_configuration", []map[string]interface{}{
 		{
-			"action_duration":        t.FailedAuthenticationConfiguration.ActionDuration,
-			"action_duration_unit":   t.FailedAuthenticationConfiguration.ActionDurationUnit,
-			"reset_count_in_seconds": t.FailedAuthenticationConfiguration.ResetCountInSeconds,
-			"too_many_attempts":      t.FailedAuthenticationConfiguration.TooManyAttempts,
-			"user_action_id":         t.FailedAuthenticationConfiguration.UserActionId,
+			"action_duration":        					t.FailedAuthenticationConfiguration.ActionDuration,
+			"action_duration_unit":   					t.FailedAuthenticationConfiguration.ActionDurationUnit,
+			"action_cancel_policy_on_password_reset":	t.FailedAuthenticationConfiguration.ActionCancelPolicy.OnPasswordReset,
+			"reset_count_in_seconds": 					t.FailedAuthenticationConfiguration.ResetCountInSeconds,
+			"too_many_attempts":      					t.FailedAuthenticationConfiguration.TooManyAttempts,
+			"user_action_id":         					t.FailedAuthenticationConfiguration.UserActionId,
 		},
 	})
 	if err != nil {

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -144,7 +144,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 				data.Get("failed_authentication_configuration.0.action_duration_unit").(string),
 			),
 			ActionCancelPolicy: fusionauth.FailedAuthenticationActionCancelPolicy{
-				OnPasswordReset:  data.Get("failed_authentication_configuration.0.action_cancel_policy_on_password_reset").(bool),
+				OnPasswordReset: data.Get("failed_authentication_configuration.0.action_cancel_policy_on_password_reset").(bool),
 			},
 			ResetCountInSeconds: data.Get("failed_authentication_configuration.0.reset_count_in_seconds").(int),
 			TooManyAttempts:     data.Get("failed_authentication_configuration.0.too_many_attempts").(int),
@@ -484,12 +484,12 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 
 	err = data.Set("failed_authentication_configuration", []map[string]interface{}{
 		{
-			"action_duration":        					t.FailedAuthenticationConfiguration.ActionDuration,
-			"action_duration_unit":   					t.FailedAuthenticationConfiguration.ActionDurationUnit,
-			"action_cancel_policy_on_password_reset":	t.FailedAuthenticationConfiguration.ActionCancelPolicy.OnPasswordReset,
-			"reset_count_in_seconds": 					t.FailedAuthenticationConfiguration.ResetCountInSeconds,
-			"too_many_attempts":      					t.FailedAuthenticationConfiguration.TooManyAttempts,
-			"user_action_id":         					t.FailedAuthenticationConfiguration.UserActionId,
+			"action_duration":                        t.FailedAuthenticationConfiguration.ActionDuration,
+			"action_duration_unit":                   t.FailedAuthenticationConfiguration.ActionDurationUnit,
+			"action_cancel_policy_on_password_reset": t.FailedAuthenticationConfiguration.ActionCancelPolicy.OnPasswordReset,
+			"reset_count_in_seconds":                 t.FailedAuthenticationConfiguration.ResetCountInSeconds,
+			"too_many_attempts":                      t.FailedAuthenticationConfiguration.TooManyAttempts,
+			"user_action_id":                         t.FailedAuthenticationConfiguration.UserActionId,
 		},
 	})
 	if err != nil {

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -169,6 +169,7 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.action_duration_unit", "DAYS"),
 		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.reset_count_in_seconds", "600"),
 		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.too_many_attempts", "3"),
+		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.action_cancel_policy_on_password_reset", "true"),
 		// resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.user_action_id", "UUID"),
 
 		// family_configuration
@@ -544,6 +545,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
     action_duration_unit   = "DAYS"
     reset_count_in_seconds = 600
     too_many_attempts      = 3
+    action_cancel_policy_on_password_reset = true
     #user_action_id         = "UUID"
   }
   family_configuration {


### PR DESCRIPTION
Update Fusionauth provider to support `actionCancelPolicy` of the Tenant failed authentication configuration.
It's available since 1.42.0.

From API doc:
> tenant.failedAuthenticationConfiguration.actionCancelPolicy.onPasswordReset [Boolean] OPTIONAL Defaults to false AVAILABLE SINCE 1.42.0
Indicates whether you want the user to be able to self-service unlock their account prior to the action duration by completing a password reset workflow.