### PR TITLE
fix: login records information being incorrectly read from admin logs fields

### DIFF
--- a/fusionauth/resource_system_configuration.go
+++ b/fusionauth/resource_system_configuration.go
@@ -350,8 +350,8 @@ func buildResourceFromSystemConfiguration(sc fusionauth.SystemConfiguration, dat
 		{
 			"delete": []map[string]interface{}{
 				{
-					"enabled":                  sc.AuditLogConfiguration.Delete.Enabled,
-					"number_of_days_to_retain": sc.AuditLogConfiguration.Delete.NumberOfDaysToRetain,
+					"enabled":                  sc.LoginRecordConfiguration.Delete.Enabled,
+					"number_of_days_to_retain": sc.LoginRecordConfiguration.Delete.NumberOfDaysToRetain,
 				},
 			},
 		},


### PR DESCRIPTION
When using Terraform to make changes to the login records section of the system configuration settings, a terraform apply indicates that changes are always required. This is because the when reading the state of the login records settings from Fusion Auth there is a bug in the code that is causing the login records settings to be read from the admin logs settings fields. I believe these changes should correct this.
