### PR TITLE
Add email user setting to failed auth configuration of tenant resource

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -529,6 +529,7 @@ resource "fusionauth_tenant" "example" {
     - `reset_count_in_seconds` - (Optional) The length of time in seconds before the failed authentication count will be reset. Value must be greater than 0.
     - `too_many_attempts` - (Optional) The number of failed attempts considered to be too many. Once this threshold is reached the specified User Action will be applied to the user for the duration specified. Value must be greater than 0.
     - `action_cancel_policy_on_password_reset` - (Optional) Indicates whether you want the user to be able to self-service unlock their account prior to the action duration by completing a password reset workflow.
+    - `email_user` - (Optional) Indicates you would like to email the user when the user’s account is locked due to this action being taken. This requires the User Action specified by the tenant.failedAuthenticationConfiguration.userActionId to also be configured for email. If the User Action is not configured to be able to email the user, this configuration will be ignored.
     - `user_action_id` - (Optional) The Id of the User Action that is applied when the threshold is reached for too many failed authentication attempts.
 * `family_configuration` - (Optional)
     - `allow_child_registrations` - (Optional) Whether to allow child registrations.

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -905,6 +905,11 @@ func newFailedAuthenticationConfiguration() *schema.Resource {
 				Optional:    true,
 				Description: "Indicates whether you want the user to be able to self-service unlock their account prior to the action duration by completing a password reset workflow.",
 			},
+			"email_user": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates you would like to email the user when the user’s account is locked due to this action being taken. This requires the User Action specified by the tenant.failedAuthenticationConfiguration.userActionId to also be configured for email. If the User Action is not configured to be able to email the user, this configuration will be ignored.",
+			},
 			"reset_count_in_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -146,6 +146,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			ActionCancelPolicy: fusionauth.FailedAuthenticationActionCancelPolicy{
 				OnPasswordReset: data.Get("failed_authentication_configuration.0.action_cancel_policy_on_password_reset").(bool),
 			},
+			EmailUser: data.Get("failed_authentication_configuration.0.email_user").(bool),
 			ResetCountInSeconds: data.Get("failed_authentication_configuration.0.reset_count_in_seconds").(int),
 			TooManyAttempts:     data.Get("failed_authentication_configuration.0.too_many_attempts").(int),
 			UserActionId:        data.Get("failed_authentication_configuration.0.user_action_id").(string),
@@ -487,6 +488,7 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 			"action_duration":                        t.FailedAuthenticationConfiguration.ActionDuration,
 			"action_duration_unit":                   t.FailedAuthenticationConfiguration.ActionDurationUnit,
 			"action_cancel_policy_on_password_reset": t.FailedAuthenticationConfiguration.ActionCancelPolicy.OnPasswordReset,
+			"email_user":							  t.FailedAuthenticationConfiguration.EmailUser,
 			"reset_count_in_seconds":                 t.FailedAuthenticationConfiguration.ResetCountInSeconds,
 			"too_many_attempts":                      t.FailedAuthenticationConfiguration.TooManyAttempts,
 			"user_action_id":                         t.FailedAuthenticationConfiguration.UserActionId,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -146,7 +146,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			ActionCancelPolicy: fusionauth.FailedAuthenticationActionCancelPolicy{
 				OnPasswordReset: data.Get("failed_authentication_configuration.0.action_cancel_policy_on_password_reset").(bool),
 			},
-			EmailUser: data.Get("failed_authentication_configuration.0.email_user").(bool),
+			EmailUser:           data.Get("failed_authentication_configuration.0.email_user").(bool),
 			ResetCountInSeconds: data.Get("failed_authentication_configuration.0.reset_count_in_seconds").(int),
 			TooManyAttempts:     data.Get("failed_authentication_configuration.0.too_many_attempts").(int),
 			UserActionId:        data.Get("failed_authentication_configuration.0.user_action_id").(string),
@@ -488,7 +488,7 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 			"action_duration":                        t.FailedAuthenticationConfiguration.ActionDuration,
 			"action_duration_unit":                   t.FailedAuthenticationConfiguration.ActionDurationUnit,
 			"action_cancel_policy_on_password_reset": t.FailedAuthenticationConfiguration.ActionCancelPolicy.OnPasswordReset,
-			"email_user":							  t.FailedAuthenticationConfiguration.EmailUser,
+			"email_user":                             t.FailedAuthenticationConfiguration.EmailUser,
 			"reset_count_in_seconds":                 t.FailedAuthenticationConfiguration.ResetCountInSeconds,
 			"too_many_attempts":                      t.FailedAuthenticationConfiguration.TooManyAttempts,
 			"user_action_id":                         t.FailedAuthenticationConfiguration.UserActionId,

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -547,7 +547,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
     reset_count_in_seconds = 600
     too_many_attempts      = 3
     action_cancel_policy_on_password_reset = true
-    email_user			   = true
+    email_user             = true
     #user_action_id         = "UUID"
   }
   family_configuration {

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -547,7 +547,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
     reset_count_in_seconds = 600
     too_many_attempts      = 3
     action_cancel_policy_on_password_reset = true
-	email_user			   = true
+    email_user			   = true
     #user_action_id         = "UUID"
   }
   family_configuration {

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -170,6 +170,7 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.reset_count_in_seconds", "600"),
 		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.too_many_attempts", "3"),
 		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.action_cancel_policy_on_password_reset", "true"),
+		resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.email_user", "true"),
 		// resource.TestCheckResourceAttr(tfResourcePath, "failed_authentication_configuration.0.user_action_id", "UUID"),
 
 		// family_configuration
@@ -546,6 +547,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
     reset_count_in_seconds = 600
     too_many_attempts      = 3
     action_cancel_policy_on_password_reset = true
+	email_user			   = true
     #user_action_id         = "UUID"
   }
   family_configuration {


### PR DESCRIPTION
## Description

`tenant.failedAuthenticationConfiguration.emailUser` was [added to the FusionAuth Tenant AP in version 1.42.0](https://github.com/FusionAuth/fusionauth-issues/issues/1823). This PR adds support for setting this value.

From the API Doc:
> tenant.failedAuthenticationConfiguration.emailUser [String] Optional defaults to false Available since 1.42.0
> 
> Indicates you would like to email the user when the user’s account is locked due to this action being taken. This requires the User Action specified by the tenant.failedAuthenticationConfiguration.userActionId to also be configured for email. If the User Action is not configured to be able to email the user, this configuration will be ignored. See userEmailingEnabled on the User Action.
> 
> The email template configuration will be in the User Action.


