### PR TITLE
Add 'Required' option to tenant multi_factor_configuration.login_policy

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -565,7 +565,7 @@ resource "fusionauth_tenant" "example" {
     - `seconds` - (Optional) The password minimum age in seconds. When enabled FusionAuth will not allow a password to be changed until it reaches this minimum age. Required when systemConfiguration.minimumPasswordAge.enabled is set to true.
     - `enabled` - (Optional) Indicates that the minimum password age is enabled and being enforced.
 * `multi_factor_configuration` - (Optional)
-    - `login_policy` - (Optional)  When set to `Enabled` and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to `Disabled`, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.
+    - `login_policy` - (Optional)  When set to `Enabled` and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to `Disabled`, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login. When the login policy is to `Required`, a two-factor challenge will be required during login. If a user does not have configured two-factor methods, they will not be able to log in.
     - `authenticator` - (Optional)
         * `enabled` - (Optional) When enabled, users may utilize an authenticator application to complete a multi-factor authentication request. This method uses TOTP (Time-Based One-Time Password) as defined in RFC 6238 and often uses an native mobile app such as Google Authenticator.
     - `email` - (Optional)

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -396,8 +396,8 @@ func newTenant() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "Enabled",
-							ValidateFunc: validation.StringInSlice([]string{fusionauth.MultiFactorLoginPolicy_Enabled.String(), fusionauth.MultiFactorLoginPolicy_Disabled.String()}, false),
-							Description:  "When set to Enabled and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to Disabled, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login.",
+							ValidateFunc: validation.StringInSlice([]string{fusionauth.MultiFactorLoginPolicy_Enabled.String(), fusionauth.MultiFactorLoginPolicy_Disabled.String(), fusionauth.MultiFactorLoginPolicy_Required.String()}, false),
+							Description:  "When set to Enabled and a user has one or more two-factor methods configured, the user will be required to complete a two-factor challenge during login. When set to Disabled, even when a user has configured one or more two-factor methods, the user will not be required to complete a two-factor challenge during login. When the login policy is to Required, a two-factor challenge will be required during login. If a user does not have configured two-factor methods, they will not be able to log in.",
 						},
 						"authenticator": {
 							Type:       schema.TypeList,


### PR DESCRIPTION
This add support for creating tenant with 'Required' multifactor login policy 

**From ducumentation:**
https://fusionauth.io/docs/v1/tech/apis/tenants

tenant.multiFactorConfiguration.loginPolicy
Supported values include:
**Enabled** - Require a two-factor challenge during login when an eligible method is available.
**Disabled** - Do not require a two-factor challenge during login.
**Required** - Require a two-factor challenge during login. A user will be required to configure 2FA if no eligible methods are available. AVAILABLE SINCE 1.42.0

