### PR TITLE
feat: add support for email configuration additional headers

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -30,9 +30,9 @@ resource "fusionauth_tenant" "example" {
     username                          = "username"
     verify_email                      = true
     verify_email_when_changed         = true
-    additional_header {
-      name = "Header-Name-1"
-      value = "Header-Value-1"
+    additional_headers = {
+      "HeaderName1" = "HeaderValue1"
+      "HeaderName2" = "HeaderValue2"
     }
   }
   event_configuration {
@@ -454,7 +454,7 @@ resource "fusionauth_tenant" "example" {
     - `migrate` - (Optional) If true, the user’s data will be migrated to FusionAuth at first successful authentication; subsequent authentications will occur against the FusionAuth datastore. If false, the Connector’s source will be treated as authoritative.
 * `data` - (Optional) An object that can hold any information about the Tenant that should be persisted.
 * `email_configuration` - (Required)
-    - `additional_header` - (Optional) A list of additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
+    - `additional_headers` - (Optional) The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
     - `email_update_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
     - `email_verified_email_template_id` - (Optional) The Id of the Email Template used to verify user emails.
     - `host` - (Required) The host name of the SMTP server that FusionAuth will use.

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -30,6 +30,10 @@ resource "fusionauth_tenant" "example" {
     username                          = "username"
     verify_email                      = true
     verify_email_when_changed         = true
+    additional_header {
+      name = "Header-Name-1"
+      value = "Header-Value-1"
+    }
   }
   event_configuration {
     enabled          = false
@@ -450,7 +454,7 @@ resource "fusionauth_tenant" "example" {
     - `migrate` - (Optional) If true, the user’s data will be migrated to FusionAuth at first successful authentication; subsequent authentications will occur against the FusionAuth datastore. If false, the Connector’s source will be treated as authoritative.
 * `data` - (Optional) An object that can hold any information about the Tenant that should be persisted.
 * `email_configuration` - (Required)
-    - `additional_headers` - (Optional) The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
+    - `additional_header` - (Optional) A list of additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.
     - `email_update_email_template_id` - (Optional) The Id of the Email Template that is used when a user is sent a forgot password email.
     - `email_verified_email_template_id` - (Optional) The Id of the Email Template used to verify user emails.
     - `host` - (Required) The host name of the SMTP server that FusionAuth will use.

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -1233,10 +1233,24 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 func newEmailConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"additional_headers": {
-				Type:        schema.TypeMap,
+			"additional_header": {
+				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.",
+				Description: "A list of  additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The email header name.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The email header value.",
+						},
+					},
+				},
 			},
 			"default_from_name": {
 				Type:        schema.TypeString,

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -1233,24 +1233,10 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 func newEmailConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"additional_header": {
-				Type:        schema.TypeList,
+			"additional_headers": {
+				Type:        schema.TypeMap,
 				Optional:    true,
-				Description: "A list of  additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The email header name.",
-						},
-						"value": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "The email header value.",
-						},
-					},
-				},
+				Description: "The additional SMTP headers to be added to each outgoing email. Each SMTP header consists of a name and a value.",
 			},
 			"default_from_name": {
 				Type:        schema.TypeString,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -12,7 +12,6 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 	tenant := fusionauth.Tenant{
 		Data: data.Get("data").(map[string]interface{}),
 		EmailConfiguration: fusionauth.EmailConfiguration{
-			// AdditionalHeaders:                    data.Get("email_configuration.0.additional_headers").(string),
 			EmailUpdateEmailTemplateId:           data.Get("email_configuration.0.email_update_email_template_id").(string),
 			EmailVerifiedEmailTemplateId:         data.Get("email_configuration.0.email_verified_email_template_id").(string),
 			ImplicitEmailVerificationAllowed:     data.Get("email_configuration.0.implicit_email_verification_allowed").(bool),
@@ -301,12 +300,52 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 		},
 	}
 
-	connectorPolicies, diags := buildConnectorPolicies(data)
-	if diags == nil {
+	connectorPolicies, connectorDiags := buildConnectorPolicies(data)
+	if connectorDiags == nil {
 		tenant.ConnectorPolicies = connectorPolicies
 	}
 
-	return tenant, diags
+	additionalheaders, emailDiags := buildAdditionalHeaders(data)
+	if emailDiags == nil {
+		tenant.EmailConfiguration.AdditionalHeaders = additionalheaders
+	}
+
+	return tenant, append(connectorDiags, emailDiags...)
+}
+
+func buildAdditionalHeaders(data *schema.ResourceData) (emailHeaders []fusionauth.EmailHeader, diags diag.Diagnostics) {
+	emailHeadersData, ok := data.Get("email_configuration.0.additional_header").([]interface{})
+	if emailHeadersData == nil || !ok {
+		if !ok {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Unable to convert additional headers data",
+				Detail:   "additional_header unable to be typecast to []interface{}",
+			})
+		}
+
+		// Nothing to do here!
+		return emailHeaders, diags
+	}
+
+	emailHeaders = make([]fusionauth.EmailHeader, len(emailHeadersData))
+
+	for i, emailHeadersDatum := range emailHeadersData {
+		if emailHeader, ok := emailHeadersDatum.(map[string]interface{}); !ok {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Unable to convert a additional header",
+				Detail:   fmt.Sprintf("additional_header.%d: %#+v unable to be typecast to map[string]interface{}", i, emailHeadersDatum),
+			})
+		} else {
+			emailHeaders[i] = fusionauth.EmailHeader{
+				Name:  emailHeader["name"].(string),
+				Value: emailHeader["value"].(string),
+			}
+		}
+	}
+
+	return emailHeaders, diags
 }
 
 func buildConnectorPolicies(data *schema.ResourceData) (connectorPolicies []fusionauth.ConnectorPolicy, diags diag.Diagnostics) {
@@ -389,9 +428,17 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 		return diag.Errorf("tenant.connector_policy: %s", err.Error())
 	}
 
+	additionalHeaders := []map[string]interface{}{}
+	for _, additionalHeader := range t.EmailConfiguration.AdditionalHeaders {
+		additionalHeaders = append(additionalHeaders, map[string]interface{}{
+			"name":  additionalHeader.Name,
+			"value": additionalHeader.Value,
+		})
+	}
+
 	err := data.Set("email_configuration", []map[string]interface{}{
 		{
-			// "additional_headers":                t.EmailConfiguration.AdditionalHeaders,
+			"additional_header":                           additionalHeaders,
 			"email_update_email_template_id":              t.EmailConfiguration.EmailUpdateEmailTemplateId,
 			"email_verified_email_template_id":            t.EmailConfiguration.EmailVerifiedEmailTemplateId,
 			"forgot_password_email_template_id":           t.EmailConfiguration.ForgotPasswordEmailTemplateId,
@@ -411,13 +458,13 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 			"set_password_email_template_id":              t.EmailConfiguration.SetPasswordEmailTemplateId,
 			"two_factor_method_add_email_template_id":     t.EmailConfiguration.TwoFactorMethodAddEmailTemplateId,
 			"two_factor_method_remove_email_template_id":  t.EmailConfiguration.TwoFactorMethodRemoveEmailTemplateId,
-			"username":                       t.EmailConfiguration.Username,
-			"verification_email_template_id": t.EmailConfiguration.VerificationEmailTemplateId,
-			"verification_strategy":          t.EmailConfiguration.VerificationStrategy,
-			"verify_email":                   t.EmailConfiguration.VerifyEmail,
-			"verify_email_when_changed":      t.EmailConfiguration.VerifyEmailWhenChanged,
-			"default_from_email":             t.EmailConfiguration.DefaultFromEmail,
-			"default_from_name":              t.EmailConfiguration.DefaultFromName,
+			"username":                                    t.EmailConfiguration.Username,
+			"verification_email_template_id":              t.EmailConfiguration.VerificationEmailTemplateId,
+			"verification_strategy":                       t.EmailConfiguration.VerificationStrategy,
+			"verify_email":                                t.EmailConfiguration.VerifyEmail,
+			"verify_email_when_changed":                   t.EmailConfiguration.VerifyEmailWhenChanged,
+			"default_from_email":                          t.EmailConfiguration.DefaultFromEmail,
+			"default_from_name":                           t.EmailConfiguration.DefaultFromName,
 			"unverified": []map[string]interface{}{{
 				"allow_email_change_when_gated": t.EmailConfiguration.Unverified.AllowEmailChangeWhenGated,
 				"behavior":                      t.EmailConfiguration.Unverified.Behavior,

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -306,11 +306,9 @@ func testAccCheckConnectorPolicies(tfResourcePath string, genericConnectorInclud
 
 func testAccCheckEmailConfigurationAdditionalHeaders(tfResourcePath string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.#", "2"),
-		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.0.name", "Header-Name-1"),
-		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.0.value", "Header-Value-1"),
-		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.1.name", "Header-Name-2"),
-		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.1.value", "Header-Value-2"),
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_headers.%", "2"),
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_headers.HeaderName1", "HeaderValue1"),
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_headers.HeaderName2", "HeaderValue2"),
 	)
 }
 
@@ -482,13 +480,9 @@ resource "fusionauth_tenant" "test_%[1]s" {
   }
   email_configuration {
     default_from_name  = "noreply"
-    additional_header {
-      name = "Header-Name-1"
-      value = "Header-Value-1"
-    }
-    additional_header {
-      name = "Header-Name-2"
-      value = "Header-Value-2"
+    additional_headers = {
+      "HeaderName1" = "HeaderValue1"
+      "HeaderName2" = "HeaderValue2"
     }
     default_from_email = "%[3]s"
     #forgot_password_email_template_id = ""

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -106,6 +106,7 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "data.lives", "here"),
 
 		// email_configuration
+		testAccCheckEmailConfigurationAdditionalHeaders(tfResourcePath),
 		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.default_from_name", "noreply"),
 		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.default_from_email", fromEmail),
 		// resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.forgot_password_email_template_id", "UUID"),
@@ -303,6 +304,16 @@ func testAccCheckConnectorPolicies(tfResourcePath string, genericConnectorInclud
 	)
 }
 
+func testAccCheckEmailConfigurationAdditionalHeaders(tfResourcePath string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.#", "2"),
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.0.name", "Header-Name-1"),
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.0.value", "Header-Value-1"),
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.1.name", "Header-Name-2"),
+		resource.TestCheckResourceAttr(tfResourcePath, "email_configuration.0.additional_header.1.value", "Header-Value-2"),
+	)
+}
+
 func testAccCheckFusionauthTenantExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -471,6 +482,14 @@ resource "fusionauth_tenant" "test_%[1]s" {
   }
   email_configuration {
     default_from_name  = "noreply"
+    additional_header {
+      name = "Header-Name-1"
+      value = "Header-Value-1"
+    }
+    additional_header {
+      name = "Header-Name-2"
+      value = "Header-Value-2"
+    }
     default_from_email = "%[3]s"
     #forgot_password_email_template_id = ""
     host               = "smtp.example.com"


### PR DESCRIPTION
Adds support for `tenant.emailConfiguration.additionalHeaders` (see https://fusionauth.io/docs/v1/tech/apis/tenants), which so far used to be commented-out.

Plan output from local testing:

```
Terraform will perform the following actions:

  # module.core.fusionauth_tenant.users will be updated in-place
  ~ resource "fusionauth_tenant" "users" {
        id                                 = "<ID>"
        name                           = "users"
        # (7 unchanged attributes hidden)

      ~ email_configuration {
          ~ additional_headers                  = {
              + "X-Mailgun-Drop-Message" = "yes"
            }
            # (15 unchanged attributes hidden)
        }

        # (20 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```