### PR TITLE
Theme doc typo correction

### DIFF
--- a/docs/resources/theme.md
+++ b/docs/resources/theme.md
@@ -1,8 +1,8 @@
 # Theme Resource
 
-This Resource is used to create a role for an Application.
+UI login themes can be configured to enable custom branding for your FusionAuth login workflow. Themes are configured per Tenant or optionally by Application.
 
-[Themes API]https://fusionauth.io/docs/v1/tech/apis/themes)
+[Themes API](https://fusionauth.io/docs/v1/tech/apis/themes)
 
 ## Example Usage
 
@@ -65,7 +65,10 @@ resource "fusionauth_theme" "mytheme" {
 ## Argument Reference
 
 * `source_theme_id` - (Optional) The optional Id of an existing Theme to make a copy of. If present, the defaultMessages, localizedMessages, templates, and stylesheet from the source Theme will be copied to the new Theme.
-* `default_messages` - (Optional) A properties file formatted String containing at least all of the message keys defined in the FusionAuth shipped messages file. Required if not copying an existing Theme.
+* `default_messages` - (Optional) A properties file formatted String containing at least all of the message keys defined in the FusionAuth shipped messages file. 
+
+~> **Note:** `default_messages` Is Required if not copying an existing Theme.
+
 * `localized_messages` - (Optional) A Map of localized versions of the messages. The key is the Locale and the value is a properties file formatted String.
 * `name` - (Required) A unique name for the Theme.
 * `stylesheet` - (Optional) A CSS stylesheet used to style the templates.


### PR DESCRIPTION
Adding a little more information to Theme docs and also correcting the link to FusionAuth's docs