### PR TITLE
Update go client, update app registration config, fix localized email templates

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -78,6 +78,10 @@ resource "fusionauth_application" "Forum" {
       enabled  = false
       required = false
     }
+    preferred_languages {
+      enabled  = false
+      required = false
+    }
     type = ""
   }
   passwordless_configuration_enabled = false
@@ -152,6 +156,9 @@ resource "fusionauth_application" "Forum" {
         * `enabled` - (Optional)
         * `required` - (Optional)
     - `last_name` - (Optional)
+        * `enabled` - (Optional)
+        * `required` - (Optional)
+    - `preferred_languages` - (Optional)
         * `enabled` - (Optional)
         * `required` - (Optional)
     - `login_id_type` - (Optional) The unique login Id that will be collected during registration, this value can be email or username. Leaving the default value of email is preferred because an email address is globally unique.

--- a/fusionauth/resource_fusionauth_application.go
+++ b/fusionauth/resource_fusionauth_application.go
@@ -798,6 +798,12 @@ func newRegistrationConfiguration() *schema.Resource {
 				Elem:     requireable(),
 				Optional: true,
 			},
+			"preferred_languages": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Elem:     requireable(),
+				Optional: true,
+			},
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/fusionauth/resource_fusionauth_application_helpers.go
+++ b/fusionauth/resource_fusionauth_application_helpers.go
@@ -75,17 +75,18 @@ func buildApplication(data *schema.ResourceData) fusionauth.Application {
 			Enableable: buildEnableable("passwordless_configuration_enabled", data),
 		},
 		RegistrationConfiguration: fusionauth.RegistrationConfiguration{
-			Enableable:      buildEnableable("registration_configuration.0.enabled", data),
-			BirthDate:       buildRequireable("registration_configuration.0.birth_date", data),
-			ConfirmPassword: data.Get("registration_configuration.0.confirm_password").(bool),
-			FormId:          data.Get("registration_configuration.0.form_id").(string),
-			FirstName:       buildRequireable("registration_configuration.0.first_name", data),
-			FullName:        buildRequireable("registration_configuration.0.full_name", data),
-			LastName:        buildRequireable("registration_configuration.0.last_name", data),
-			MiddleName:      buildRequireable("registration_configuration.0.middle_name", data),
-			MobilePhone:     buildRequireable("registration_configuration.0.mobile_phone", data),
-			LoginIdType:     fusionauth.LoginIdType(data.Get("registration_configuration.0.login_id_type").(string)),
-			Type:            fusionauth.RegistrationType(data.Get("registration_configuration.0.type").(string)),
+			Enableable:         buildEnableable("registration_configuration.0.enabled", data),
+			BirthDate:          buildRequireable("registration_configuration.0.birth_date", data),
+			ConfirmPassword:    data.Get("registration_configuration.0.confirm_password").(bool),
+			FormId:             data.Get("registration_configuration.0.form_id").(string),
+			FirstName:          buildRequireable("registration_configuration.0.first_name", data),
+			FullName:           buildRequireable("registration_configuration.0.full_name", data),
+			LastName:           buildRequireable("registration_configuration.0.last_name", data),
+			MiddleName:         buildRequireable("registration_configuration.0.middle_name", data),
+			MobilePhone:        buildRequireable("registration_configuration.0.mobile_phone", data),
+			PreferredLanguages: buildRequireable("registration_configuration.0.preferred_languages", data),
+			LoginIdType:        fusionauth.LoginIdType(data.Get("registration_configuration.0.login_id_type").(string)),
+			Type:               fusionauth.RegistrationType(data.Get("registration_configuration.0.type").(string)),
 		},
 		RegistrationDeletePolicy: fusionauth.ApplicationRegistrationDeletePolicy{
 			Unverified: fusionauth.TimeBasedDeletePolicy{
@@ -337,6 +338,12 @@ func buildResourceDataFromApplication(a fusionauth.Application, data *schema.Res
 				{
 					"enabled":  a.RegistrationConfiguration.MobilePhone.Enabled,
 					"required": a.RegistrationConfiguration.MobilePhone.Required,
+				},
+			},
+			"preferred_languages": []map[string]interface{}{
+				{
+					"enabled":  a.RegistrationConfiguration.PreferredLanguages.Enabled,
+					"required": a.RegistrationConfiguration.PreferredLanguages.Required,
 				},
 			},
 			"login_id_type": a.RegistrationConfiguration.LoginIdType,

--- a/fusionauth/resource_fusionauth_email.go
+++ b/fusionauth/resource_fusionauth_email.go
@@ -58,9 +58,10 @@ func newEmail() *schema.Resource {
 				Description: "The From Name used when sending emails to users who speak other languages. This overrides the default From Name based on the user’s list of preferred languages.",
 			},
 			"localized_html_templates": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Description: "The HTML Email Template used when sending emails to users who speak other languages. This overrides the default HTML Email Template based on the user’s list of preferred languages.",
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Description:      "The HTML Email Template used when sending emails to users who speak other languages. This overrides the default HTML Email Template based on the user’s list of preferred languages.",
+				DiffSuppressFunc: diffSuppressTemplate,
 			},
 			"localized_subjects": {
 				Type:        schema.TypeMap,
@@ -68,9 +69,10 @@ func newEmail() *schema.Resource {
 				Description: "The Subject used when sending emails to users who speak other languages. This overrides the default Subject based on the user’s list of preferred languages.",
 			},
 			"localized_text_templates": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Description: "The Text Email Template used when sending emails to users who speak other languages. This overrides the default Text Email Template based on the user’s list of preferred languages.",
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Description:      "The Text Email Template used when sending emails to users who speak other languages. This overrides the default Text Email Template based on the user’s list of preferred languages.",
+				DiffSuppressFunc: diffSuppressTemplate,
 			},
 			"name": {
 				Type:         schema.TypeString,

--- a/fusionauth/resource_fusionauth_generic_connector.go
+++ b/fusionauth/resource_fusionauth_generic_connector.go
@@ -108,10 +108,10 @@ func buildGenericConnector(data *schema.ResourceData) fusionauth.GenericConnecto
 	return connector
 }
 
-func createGenericConnector(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+func createGenericConnector(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	connector := buildGenericConnector(data)
-	resp, faErrs, err := CreateConnector(client.FAClient, connector.Id, GenericConnectorRequest{Connector: connector})
+	resp, faErrs, err := CreateConnector(ctx, client.FAClient, connector.Id, GenericConnectorRequest{Connector: connector})
 	if err != nil {
 		return diag.Errorf("CreateGenericConnector err: %v", err)
 	}
@@ -123,11 +123,11 @@ func createGenericConnector(_ context.Context, data *schema.ResourceData, i inte
 	return nil
 }
 
-func readGenericConnector(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+func readGenericConnector(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	id := data.Id()
 
-	resp, faErrs, err := RetrieveConnector(client.FAClient, id)
+	resp, faErrs, err := RetrieveConnector(ctx, client.FAClient, id)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -175,11 +175,11 @@ func readGenericConnector(_ context.Context, data *schema.ResourceData, i interf
 	return nil
 }
 
-func updateGenericConnector(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+func updateGenericConnector(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	client := i.(Client)
 	connector := buildGenericConnector(data)
 
-	resp, faErrs, err := UpdateConnector(client.FAClient, data.Id(), GenericConnectorRequest{Connector: connector})
+	resp, faErrs, err := UpdateConnector(ctx, client.FAClient, data.Id(), GenericConnectorRequest{Connector: connector})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,19 +221,19 @@ func (b *GenericConnectorResponse) SetStatus(status int) {
 	b.StatusCode = status
 }
 
-func CreateConnector(client fusionauth.FusionAuthClient, connectorID string, request GenericConnectorRequest) (*GenericConnectorResponse, *fusionauth.Errors, error) {
-	return makeConnectorRequest(client, connectorID, request, http.MethodPost)
+func CreateConnector(ctx context.Context, client fusionauth.FusionAuthClient, connectorID string, request GenericConnectorRequest) (*GenericConnectorResponse, *fusionauth.Errors, error) {
+	return makeConnectorRequest(ctx, client, connectorID, request, http.MethodPost)
 }
 
-func RetrieveConnector(client fusionauth.FusionAuthClient, connectorID string) (*GenericConnectorResponse, *fusionauth.Errors, error) {
-	return makeConnectorRequest(client, connectorID, GenericConnectorRequest{}, http.MethodGet)
+func RetrieveConnector(ctx context.Context, client fusionauth.FusionAuthClient, connectorID string) (*GenericConnectorResponse, *fusionauth.Errors, error) {
+	return makeConnectorRequest(ctx, client, connectorID, GenericConnectorRequest{}, http.MethodGet)
 }
 
-func UpdateConnector(client fusionauth.FusionAuthClient, connectorID string, request GenericConnectorRequest) (*GenericConnectorResponse, *fusionauth.Errors, error) {
-	return makeConnectorRequest(client, connectorID, request, http.MethodPut)
+func UpdateConnector(ctx context.Context, client fusionauth.FusionAuthClient, connectorID string, request GenericConnectorRequest) (*GenericConnectorResponse, *fusionauth.Errors, error) {
+	return makeConnectorRequest(ctx, client, connectorID, request, http.MethodPut)
 }
 
-func makeConnectorRequest(client fusionauth.FusionAuthClient, connectorID string, request GenericConnectorRequest, method string) (*GenericConnectorResponse, *fusionauth.Errors, error) {
+func makeConnectorRequest(ctx context.Context, client fusionauth.FusionAuthClient, connectorID string, request GenericConnectorRequest, method string) (*GenericConnectorResponse, *fusionauth.Errors, error) {
 	var resp GenericConnectorResponse
 	var errors fusionauth.Errors
 
@@ -242,7 +242,7 @@ func makeConnectorRequest(client fusionauth.FusionAuthClient, connectorID string
 		WithUriSegment(connectorID).
 		WithJSONBody(request).
 		WithMethod(method).
-		Do()
+		Do(ctx)
 	if restClient.ErrorRef == nil {
 		return &resp, nil, err
 	}

--- a/fusionauth/resource_fusionauth_generic_connector_test.go
+++ b/fusionauth/resource_fusionauth_generic_connector_test.go
@@ -114,7 +114,7 @@ func testAccCheckGenericConnectorExists(resourceName string) resource.TestCheckF
 			return fmt.Errorf("no resource id is set")
 		}
 
-		connector, faErrs, err := RetrieveConnector(fusionauthClient(), rs.Primary.ID)
+		connector, faErrs, err := RetrieveConnector(context.Background(), fusionauthClient(), rs.Primary.ID)
 		if errs := checkFusionauthErrors(faErrs, err); errs != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func testAccCheckGenericConnectorDestroy(s *terraform.State) error {
 
 		// Ensure we retry for eventual consistency in HA setups.
 		err := resource.RetryContext(context.Background(), retryTimeout, func() *resource.RetryError {
-			connector, faErrs, err := RetrieveConnector(fusionauthClient(), rs.Primary.ID)
+			connector, faErrs, err := RetrieveConnector(context.Background(), fusionauthClient(), rs.Primary.ID)
 			if errs := checkFusionauthRetryErrors(faErrs, err); errs != nil {
 				return errs
 			}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gpsinsight/terraform-provider-fusionauth
 go 1.18
 
 require (
-	github.com/FusionAuth/go-client v0.0.0-20230313183733-29fd62bc04f7
+	github.com/FusionAuth/go-client v0.0.0-20230727220333-2d8a30ba4996
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/FusionAuth/go-client v0.0.0-20230313183733-29fd62bc04f7 h1:NQgZJFG6wHSr+R5ni/orajx1eB/O1GUPcxvgi7kZhJs=
 github.com/FusionAuth/go-client v0.0.0-20230313183733-29fd62bc04f7/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
+github.com/FusionAuth/go-client v0.0.0-20230727220333-2d8a30ba4996 h1:m1BEFfqQRaTUdyxhHXTSBaQWCI22IULsDtObQX+uweU=
+github.com/FusionAuth/go-client v0.0.0-20230727220333-2d8a30ba4996/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=


### PR DESCRIPTION
* feat: Updated the FusionAuth go client to the latest version for 1.47.1

* feat(resource_fusionauth_application): Support the new preferred_languages field in application registration configuration

* fix(resource_fusionauth_email): Prevent localized email templates from perpetually registering as changed