### PR TITLE
Add refresh token sliding window configuration

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -561,6 +561,7 @@ resource "fusionauth_tenant" "example" {
     - `refresh_token_expiration_policy` - (Optional) The refresh token expiration policy.
     - `refresh_token_revocation_policy_on_login_prevented` - (Optional) When enabled, the refresh token will be revoked when a user action, such as locking an account based on a number of failed login attempts, prevents user login.
     - `refresh_token_revocation_policy_on_password_change` - (Optional) When enabled, the refresh token will be revoked when a user changes their password."
+    - `refresh_token_sliding_window_maximum_time_to_live_in_minutes` - (Optional) The maximum lifetime of a refresh token when using a refresh token expiration policy of SlidingWindowWithMaximumLifetime. Value must be greater than 0.
     - `refresh_token_time_to_live_in_minutes` - (Required) The length of time in minutes a Refresh Token is valid from the time it was issued. Value must be greater than 0.
     - `refresh_token_usage_policy` - (Optional) The refresh token usage policy.
     - `time_to_live_in_seconds` - (Required) The length of time in seconds this JWT is valid from the time it was issued. Value must be greater than 0.

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -282,6 +282,7 @@ func newTenant() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								"Fixed",
 								"SlidingWindow",
+								"SlidingWindowWithMaximumLifetime",
 							}, false),
 							Description: "The refresh token expiration policy.",
 						},
@@ -294,6 +295,12 @@ func newTenant() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: "When enabled, the refresh token will be revoked when a user changes their password.",
+						},
+						"refresh_token_sliding_window_maximum_time_to_live_in_minutes": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "The maximum lifetime of a refresh token when using a refresh token expiration policy of SlidingWindowWithMaximumLifetime. Value must be greater than 0.",
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"refresh_token_time_to_live_in_minutes": {
 							Type:         schema.TypeInt,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -182,7 +182,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			RefreshTokenUsagePolicy:         fusionauth.RefreshTokenUsagePolicy(data.Get("jwt_configuration.0.refresh_token_usage_policy").(string)),
 			TimeToLiveInSeconds:             data.Get("jwt_configuration.0.time_to_live_in_seconds").(int),
 			RefreshTokenSlidingWindowConfiguration: fusionauth.RefreshTokenSlidingWindowConfiguration{
-				MaximumTimeToLiveInMinutes:	data.Get("jwt_configuration.0.refresh_token_sliding_window_maximum_time_to_live_in_minutes").(int),
+				MaximumTimeToLiveInMinutes: data.Get("jwt_configuration.0.refresh_token_sliding_window_maximum_time_to_live_in_minutes").(int),
 			},
 		},
 		LoginConfiguration: fusionauth.TenantLoginConfiguration{
@@ -581,14 +581,14 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 
 	err = data.Set("jwt_configuration", []map[string]interface{}{
 		{
-			"access_token_key_id":                                t.JwtConfiguration.AccessTokenKeyId,
-			"id_token_key_id":                                    t.JwtConfiguration.IdTokenKeyId,
-			"refresh_token_expiration_policy":                    t.JwtConfiguration.RefreshTokenExpirationPolicy,
-			"refresh_token_revocation_policy_on_login_prevented": t.JwtConfiguration.RefreshTokenRevocationPolicy.OnLoginPrevented,
-			"refresh_token_revocation_policy_on_password_change": t.JwtConfiguration.RefreshTokenRevocationPolicy.OnPasswordChanged,
-			"refresh_token_usage_policy":                         t.JwtConfiguration.RefreshTokenUsagePolicy,
-			"refresh_token_time_to_live_in_minutes":              t.JwtConfiguration.RefreshTokenTimeToLiveInMinutes,
-			"time_to_live_in_seconds":                            t.JwtConfiguration.TimeToLiveInSeconds,
+			"access_token_key_id":                                          t.JwtConfiguration.AccessTokenKeyId,
+			"id_token_key_id":                                              t.JwtConfiguration.IdTokenKeyId,
+			"refresh_token_expiration_policy":                              t.JwtConfiguration.RefreshTokenExpirationPolicy,
+			"refresh_token_revocation_policy_on_login_prevented":           t.JwtConfiguration.RefreshTokenRevocationPolicy.OnLoginPrevented,
+			"refresh_token_revocation_policy_on_password_change":           t.JwtConfiguration.RefreshTokenRevocationPolicy.OnPasswordChanged,
+			"refresh_token_usage_policy":                                   t.JwtConfiguration.RefreshTokenUsagePolicy,
+			"refresh_token_time_to_live_in_minutes":                        t.JwtConfiguration.RefreshTokenTimeToLiveInMinutes,
+			"time_to_live_in_seconds":                                      t.JwtConfiguration.TimeToLiveInSeconds,
 			"refresh_token_sliding_window_maximum_time_to_live_in_minutes": t.JwtConfiguration.RefreshTokenSlidingWindowConfiguration.MaximumTimeToLiveInMinutes,
 		},
 	})

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -181,6 +181,9 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			RefreshTokenTimeToLiveInMinutes: data.Get("jwt_configuration.0.refresh_token_time_to_live_in_minutes").(int),
 			RefreshTokenUsagePolicy:         fusionauth.RefreshTokenUsagePolicy(data.Get("jwt_configuration.0.refresh_token_usage_policy").(string)),
 			TimeToLiveInSeconds:             data.Get("jwt_configuration.0.time_to_live_in_seconds").(int),
+			RefreshTokenSlidingWindowConfiguration: fusionauth.RefreshTokenSlidingWindowConfiguration{
+				MaximumTimeToLiveInMinutes:	data.Get("jwt_configuration.0.refresh_token_sliding_window_maximum_time_to_live_in_minutes").(int),
+			},
 		},
 		LoginConfiguration: fusionauth.TenantLoginConfiguration{
 			RequireAuthentication: data.Get("login_configuration.0.require_authentication").(bool),
@@ -586,6 +589,7 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 			"refresh_token_usage_policy":                         t.JwtConfiguration.RefreshTokenUsagePolicy,
 			"refresh_token_time_to_live_in_minutes":              t.JwtConfiguration.RefreshTokenTimeToLiveInMinutes,
 			"time_to_live_in_seconds":                            t.JwtConfiguration.TimeToLiveInSeconds,
+			"refresh_token_sliding_window_maximum_time_to_live_in_minutes": t.JwtConfiguration.RefreshTokenSlidingWindowConfiguration.MaximumTimeToLiveInMinutes,
 		},
 	})
 	if err != nil {

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -198,6 +198,7 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttrSet(tfResourcePath, "jwt_configuration.0.id_token_key_id"),
 		resource.TestCheckResourceAttr(tfResourcePath, "jwt_configuration.0.refresh_token_time_to_live_in_minutes", "43200"),
 		resource.TestCheckResourceAttr(tfResourcePath, "jwt_configuration.0.time_to_live_in_seconds", "3600"),
+		resource.TestCheckResourceAttr(tfResourcePath, "jwt_configuration.0.refresh_token_sliding_window_maximum_time_to_live_in_minutes", "43200"),
 
 		// login_configuration
 		resource.TestCheckResourceAttr(tfResourcePath, "login_configuration.0.require_authentication", "true"),
@@ -590,6 +591,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
   jwt_configuration {
     refresh_token_time_to_live_in_minutes = 43200
     time_to_live_in_seconds               = 3600
+	refresh_token_sliding_window_maximum_time_to_live_in_minutes = 43200
   }
   login_configuration {
     require_authentication = true


### PR DESCRIPTION
Version 1.46.0 of FusionAuth introduced the following new configuration options for `tenant.jwtConfiguration`:

1. `refreshTokenExpirationPolicy`: `SlidingWindowWithMaximumLifetime`
2. `refreshTokenSlidingWindowConfiguration.maximumTimeToLiveInMinutes`

See: https://fusionauth.io/docs/v1/tech/apis/tenants

![Screenshot 2023-10-25 162421](https://github.com/gpsinsight/terraform-provider-fusionauth/assets/3971132/e94a5669-427c-4a77-88c0-0801db2a69ae)


![Screenshot 2023-10-25 162446](https://github.com/gpsinsight/terraform-provider-fusionauth/assets/3971132/741a2738-ccb6-474c-b771-92ab348188de)

These changes aim to allow managing these values via the terraform provider. Specifically:

- Added `SlidingWindowWithMaximumLifetime` as an allowed value for `jwt_configuration`.`refresh_token_expiration_policy`
- Added `refresh_token_sliding_window_maximum_time_to_live_in_minutes` to `jwt_configuration` for setting a custom TTL value
- Updated documentation